### PR TITLE
ログイン周りのバグ修正

### DIFF
--- a/webapp/golang/main.go
+++ b/webapp/golang/main.go
@@ -178,7 +178,7 @@ func (h *handlers) Login(c echo.Context) error {
 	}
 	if s, ok := sess.Values["userID"].(string); ok {
 		userID := uuid.Parse(s)
-		if !sess.IsNew && uuid.Equal(userID, req.ID) {
+		if uuid.Equal(userID, req.ID) {
 			return echo.NewHTTPError(http.StatusBadRequest, "You are already logged in.")
 		}
 	}


### PR DESCRIPTION
- セッションが空のときエラーになっていたので変換時にチェックを入れるように修正
- `UUID` 型をセッションに入れると↓のように怒られたので `String` に変換するように修正

```
"error":"code=500, message=save session: securecookie: error - caused by: securecookie: error - caused by: gob: type not registered for interface: uuid.UUID"
```