### PR TITLE
initializeで実装言語を返すように変更

### DIFF
--- a/webapp/golang/main.go
+++ b/webapp/golang/main.go
@@ -104,7 +104,10 @@ func (h *handlers) Initialize(c echo.Context) error {
 		}
 	}
 
-	return c.NoContent(http.StatusOK)
+	res := InitializeResponse{
+		Language: "go",
+	}
+	return c.JSON(http.StatusOK, res)
 }
 
 func (h *handlers) IsLoggedIn(next echo.HandlerFunc) echo.HandlerFunc {
@@ -144,6 +147,10 @@ func (h *handlers) IsAdmin(next echo.HandlerFunc) echo.HandlerFunc {
 
 func (h *handlers) SetPhase(c echo.Context) error {
 	panic("implement me")
+}
+
+type InitializeResponse struct {
+	Language string `json:"language"`
 }
 
 type LoginRequest struct {


### PR DESCRIPTION
`/initialize` のレスポンスで以下のように実装言語を返却するように修正しました。
```
{
  "language": "go"
}
```

close #28 