### PR TITLE
カラーパレットの追加

### DIFF
--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -10,6 +10,7 @@
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
     "lint:style": "stylelint \"**/*.{vue,css}\" --ignore-path .gitignore",
     "lint": "yarn lint:js && yarn lint:style",
+    "lint:fix": "yarn lint:js --fix && yarn lint:style --fix",
     "test": "jest"
   },
   "lint-staged": {

--- a/webapp/frontend/tailwind.config.js
+++ b/webapp/frontend/tailwind.config.js
@@ -1,0 +1,38 @@
+const colors = require('tailwindcss/colors')
+
+module.exports = {
+  theme: {
+    colors: {
+      transparent: 'transparent',
+      current: 'currentColor',
+      primary: {
+        50: '#eef5f2',
+        100: '#cef0ed',
+        200: '#95e8d5',
+        300: '#59d0a9',
+        400: '#1eb379',
+        500: '#19935c',
+        600: '#13853b',
+        700: '#136630',
+        800: '#0f4626',
+        900: '#0b2b1e',
+      },
+      secondary: {
+        50: '#fdfcfb',
+        100: '#fbf0f0',
+        200: '#f6cfe0',
+        300: '#eba2c0',
+        400: '#e8739a',
+        500: '#da4f7b',
+        600: '#c2355a',
+        700: '#9a2842',
+        800: '#6f1c2b',
+        900: '#431117',
+      },
+      neutral: colors.gray,
+      black: colors.black,
+      white: colors.white,
+      gray: colors.gray,
+    },
+  },
+}


### PR DESCRIPTION
### 概要

カラーパレットを追加しました。
`bg-primary-500` といった形でCSS当てるためのクラスが自動生成されます。
`primary`, `secondary`, `white`, `black`, `gray` で足りると思いますが足りなかったら追加します