### PR TITLE
お知らせ関連の修正

### DIFF
--- a/webapp/golang/main.go
+++ b/webapp/golang/main.go
@@ -1268,7 +1268,7 @@ func (h *handlers) GetAnnouncementList(c echo.Context) error {
 		" FROM `announcements`" +
 		" JOIN `courses` ON `announcements`.`course_id` = `courses`.`id`" +
 		" JOIN `registrations` ON `courses`.`id` = `registrations`.`course_id`" +
-		" LEFT JOIN `unread_announcements` ON `announcements`.`id` = `unread_announcements`.`announcement_id`" +
+		" JOIN `unread_announcements` ON `announcements`.`id` = `unread_announcements`.`announcement_id`" +
 		" WHERE 1=1"
 
 	if courseID := c.QueryParam("course_id"); courseID != "" {
@@ -1371,9 +1371,10 @@ func (h *handlers) GetAnnouncementDetail(c echo.Context) error {
 	query := "SELECT `announcements`.`id`, `courses`.`id` AS `course_id`, `courses`.`name` AS `course_name`, `announcements`.`title`, `announcements`.`message`, `unread_announcements`.`deleted_at` IS NULL AS `unread`, `announcements`.`created_at`" +
 		" FROM `announcements`" +
 		" JOIN `courses` ON `courses`.`id` = `announcements`.`course_id`" +
-		" LEFT JOIN `unread_announcements` ON `unread_announcements`.`announcement_id` = `announcements`.`id` AND `unread_announcements`.`user_id` = ?" +
-		" WHERE `announcements`.`id` = ?"
-	if err := h.DB.Get(&announcement, query, userID, announcementID); err == sql.ErrNoRows {
+		" JOIN `unread_announcements` ON `unread_announcements`.`announcement_id` = `announcements`.`id`" +
+		" WHERE `announcements`.`id` = ?" +
+		" AND `unread_announcements`.`user_id` = ?"
+	if err := h.DB.Get(&announcement, query, announcementID, userID); err == sql.ErrNoRows {
 		return echo.NewHTTPError(http.StatusNotFound, "No such announcement.")
 	} else if err != nil {
 		c.Logger().Error(err)


### PR DESCRIPTION
以下のissueに記述のある修正をしました

closes #164 
closes #166 
closes #167 
closes #168 

その他の事項
- `POST /courses/:courseID/classes`, `POST /announcements` のみ(教員が)created_atの時刻を設定できるように
  - 一緒に作成されるclasses, unread_announcementsのcreated_atも一緒にこの時刻にしてしまった
- 「全学生向けのお知らせ」は必要無い/現在考慮されていないようなので一旦削除