### PR TITLE
履修登録していない場合は空配列を返す

### DIFF
--- a/webapp/golang/main.go
+++ b/webapp/golang/main.go
@@ -302,7 +302,7 @@ func (h *handlers) GetRegisteredCourses(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	var res []GetRegisteredCourseResponseContent
+	res := make([]GetRegisteredCourseResponseContent, 0, len(courses))
 	for _, course := range courses {
 		var teacher User
 		if err := h.DB.Get(&teacher, "SELECT * FROM `users` WHERE `id` = ?", course.TeacherID); err != nil {


### PR DESCRIPTION
現状の実装では履修登録していない場合は `null` が返ってきますが扱いにくいので空配列を返すようにしました。