### PR TITLE
use helper for course type and course period in syllabus detail page

### DIFF
--- a/webapp/frontend/pages/syllabus/_id.vue
+++ b/webapp/frontend/pages/syllabus/_id.vue
@@ -187,10 +187,10 @@ export default Vue.extend({
     }
   },
   computed: {
-    courseType(): String {
+    courseType(): string {
       return formatType(this.course.type)
     },
-    coursePeriod(): String {
+    coursePeriod(): string {
       return formatPeriod(this.course.dayOfWeek, this.course.period)
     },
   },

--- a/webapp/frontend/types/courses.d.ts
+++ b/webapp/frontend/types/courses.d.ts
@@ -53,7 +53,7 @@ export type AnnouncementResponse = {
 
 export type GetAnnouncementResponse = {
   unreadCount: number
-  announcements: Array<AnnouncementResponse>
+  announcements: AnnouncementResponse[]
 }
 
 export type ClassInfo = {


### PR DESCRIPTION
syllabus/:id ページの表示を course_helper.tsの関数を使う形に変更しました。
