### PR TITLE
マイページの修正

### DIFF
--- a/webapp/frontend/components/CalendarCell.vue
+++ b/webapp/frontend/components/CalendarCell.vue
@@ -1,13 +1,7 @@
 <template>
   <div
-    class="
-      border
-      transition
-      cursor-pointer
-      duration-500
-      ease
-      hover:bg-primary-100
-    "
+    class="border transition duration-500 ease hover:bg-primary-100"
+    :class="cursorType"
   >
     <div
       class="
@@ -32,5 +26,17 @@
 <script lang="ts">
 import Vue from 'vue'
 
-export default Vue.extend({})
+export default Vue.extend({
+  props: {
+    cursor: {
+      type: String,
+      default: 'default',
+    },
+  },
+  computed: {
+    cursorType(): string {
+      return `cursor-${this.cursor}`
+    },
+  },
+})
 </script>

--- a/webapp/frontend/components/SearchModal.vue
+++ b/webapp/frontend/components/SearchModal.vue
@@ -169,6 +169,7 @@ import {
 import { formatPeriod, formatType } from '~/helpers/course_helper'
 import Pagination from '~/components/common/Pagination.vue'
 import { Link, parseLinkHeader } from '~/helpers/link_helper'
+import { PeriodCount } from '~/constants/calendar'
 
 type Selected = {
   dayOfWeek: DayOfWeek | undefined
@@ -199,10 +200,6 @@ export default Vue.extend({
       default: false,
       required: true,
     },
-    periodCount: {
-      type: Number,
-      default: 6,
-    },
     selected: {
       type: Object as PropType<Selected>,
       default: () => ({ dayOfWeek: undefined, period: undefined }),
@@ -226,7 +223,7 @@ export default Vue.extend({
       return this.courses.length > 0
     },
     periods() {
-      return new Array(this.periodCount).fill(undefined).map((_, i) => {
+      return new Array(PeriodCount).fill(undefined).map((_, i) => {
         return { text: `${i + 1}`, value: i + 1 }
       })
     },

--- a/webapp/frontend/constants/calendar.ts
+++ b/webapp/frontend/constants/calendar.ts
@@ -1,0 +1,9 @@
+export const WeekdayCount = 5
+export const PeriodCount = 6
+export const DayOfWeekMap = {
+  monday: 0,
+  tuesday: 1,
+  wednesday: 2,
+  thursday: 3,
+  friday: 4,
+}

--- a/webapp/frontend/pages/register.vue
+++ b/webapp/frontend/pages/register.vue
@@ -53,17 +53,7 @@ import Calendar from '../components/Calendar.vue'
 import CalendarCell from '../components/CalendarCell.vue'
 import SearchModal from '../components/SearchModal.vue'
 import { Course, DayOfWeek } from '~/types/courses'
-
-const dayOfWeekIndex = {
-  monday: 0,
-  tuesday: 1,
-  wednesday: 2,
-  thursday: 3,
-  friday: 4,
-}
-
-const weekdayCount = 5
-const periodCount = 6
+import { DayOfWeekMap, WeekdayCount, PeriodCount } from '~/constants/calendar'
 
 type PartialCourse = Partial<Course>
 
@@ -71,7 +61,6 @@ type DataType = {
   isShownModal: boolean
   selected: { dayOfWeek: DayOfWeek | undefined; period: number | undefined }
   willRegisterCourses: Course[]
-  periodCount: number
 }
 
 export default Vue.extend({
@@ -87,20 +76,19 @@ export default Vue.extend({
       isShownModal: false,
       selected: { dayOfWeek: undefined, period: undefined },
       willRegisterCourses: [],
-      periodCount,
     }
   },
   computed: {
     courses(): PartialCourse[] {
-      return new Array(weekdayCount * periodCount)
+      return new Array(WeekdayCount * PeriodCount)
         .fill(undefined)
         .map((_, i) => {
           const course = this.getCourse(i)
           if (!course) {
-            const dayOfWeek = (Object.keys(dayOfWeekIndex) as DayOfWeek[]).find(
-              (k) => dayOfWeekIndex[k] === i % weekdayCount
+            const dayOfWeek = (Object.keys(DayOfWeekMap) as DayOfWeek[]).find(
+              (k) => DayOfWeekMap[k] === i % WeekdayCount
             )
-            const period = Math.floor(i / weekdayCount) + 1
+            const period = Math.floor(i / WeekdayCount) + 1
 
             return { id: undefined, dayOfWeek, period }
           }
@@ -112,8 +100,8 @@ export default Vue.extend({
   methods: {
     getCourse(idx: number): Course | undefined {
       return this.willRegisterCourses.find((c) => {
-        const dayOfWeek = dayOfWeekIndex[c.dayOfWeek as DayOfWeek]
-        return idx === dayOfWeek + (c.period - 1) * weekdayCount
+        const dayOfWeek = DayOfWeekMap[c.dayOfWeek as DayOfWeek]
+        return idx === dayOfWeek + (c.period - 1) * WeekdayCount
       })
     },
     onClickSearchCourse(c: PartialCourse | undefined): void {


### PR DESCRIPTION
#160

### 概要

マイページで履修済み科目を表示できるようにしました。

### 詳細

- 仮データを表示していたので、APIから取得した履修済み科目をカレンダーに表示するように
- #244 で時限数を6にしたので、定数化して変更しやすいように対応
- 時限数6でちょうどいいので、表示上は10秒で1コマ進む形で「開講中の科目」を表示するように

### 注

#160 では「お知らせがあるかどうか表示」がありますが、ヘッダの処理なので共通処理部分で対応します