### PR TITLE
コース終了処理の修正

### DIFF
--- a/benchmarker/scenario/action.go
+++ b/benchmarker/scenario/action.go
@@ -307,7 +307,15 @@ func PostGradeAction(ctx context.Context, agent *agent.Agent, courseID, classID 
 	return hres, nil
 }
 
-func SetCourseStatusAction(ctx context.Context, agent *agent.Agent, courseID string, status api.CourseStatus) (*http.Response, error) {
+func SetCourseStatusInProgressAction(ctx context.Context, agent *agent.Agent, courseID string) (*http.Response, error) {
+	return setCourseStatusAction(ctx, agent, courseID, api.StatusInProgress)
+}
+
+func SetCourseStatusClosedAction(ctx context.Context, agent *agent.Agent, courseID string) (*http.Response, error) {
+	return setCourseStatusAction(ctx, agent, courseID, api.StatusClosed)
+}
+
+func setCourseStatusAction(ctx context.Context, agent *agent.Agent, courseID string, status api.CourseStatus) (*http.Response, error) {
 	hres, err := api.SetCourseStatus(ctx, agent, courseID, status)
 	if err != nil {
 		return hres, failure.NewError(fails.ErrHTTP, err)

--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -12,7 +12,6 @@ import (
 	"github.com/isucon/isucandar/failure"
 	"github.com/isucon/isucandar/parallel"
 
-	"github.com/isucon/isucon11-final/benchmarker/api"
 	"github.com/isucon/isucon11-final/benchmarker/fails"
 	"github.com/isucon/isucon11-final/benchmarker/generate"
 	"github.com/isucon/isucon11-final/benchmarker/model"
@@ -332,7 +331,7 @@ func (s *Scenario) createLoadCourseWorker(ctx context.Context, step *isucandar.B
 
 			faculty := course.Faculty()
 			// コースステータスをin-progressにする
-			_, err := SetCourseStatusAction(ctx, faculty.Agent, course.ID, api.StatusInProgress)
+			_, err := SetCourseStatusInProgressAction(ctx, faculty.Agent, course.ID)
 			if err != nil {
 				step.AddError(err)
 				AdminLogger.Printf("%vのコースステータスをin-progressに変更するのが失敗しました", course.Name)
@@ -415,7 +414,7 @@ func (s *Scenario) createLoadCourseWorker(ctx context.Context, step *isucandar.B
 			}
 
 			// コースステータスをclosedにする
-			_, err = SetCourseStatusAction(ctx, faculty.Agent, course.ID, api.StatusClosed)
+			_, err = SetCourseStatusClosedAction(ctx, faculty.Agent, course.ID)
 			if err != nil {
 				step.AddError(err)
 				AdminLogger.Printf("%vのコースステータスをclosedに変更するのが失敗しました", course.Name)


### PR DESCRIPTION
- コース終了時にstatusをclosedに変更するリクエストを投げるように修正
- ベンチで管理する学生の空きコマを開放していなかったので解放するように修正
  - リクエストエラーなどでコースが途中終了されることがあるのでdeferで対応。（そもそもコースの途中終了があってよいのかは考えたほうが良さそうだが一旦保留）

close #265