### PR TITLE
SetMaxOpenConnsの追加

### DIFF
--- a/webapp/golang/main.go
+++ b/webapp/golang/main.go
@@ -48,6 +48,7 @@ func main() {
 	e.Use(session.Middleware(sessions.NewCookieStore([]byte("trapnomura"))))
 
 	db, _ := GetDB(false)
+	db.SetMaxOpenConns(10)
 
 	h := &handlers{
 		DB: db,


### PR DESCRIPTION
Go側でmax connectionsを設定しないと、ベンチを回したときにMySQL側の最大接続数を超えて接続しようとして500で落ちるので設定を追加しました。
値は10-finalや11-qualifyと同様に10に設定してあります。
https://github.com/isucon/isucon10-final/blob/master/webapp/golang/cmd/xsuportal/main.go#L65