### PR TITLE
【WIP】履修可能コースのValidation

### DIFF
--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -418,6 +418,7 @@ func courseScenario(course *model.Course, step *isucandar.BenchmarkStep, s *Scen
 			AdminLogger.Printf("%vのコースステータスをin-progressに変更するのが失敗しました", course.Name)
 			return
 		}
+		s.RemoveRegistrableCourses(course)
 		AdminLogger.Printf("%vが開始した", course.Name) // FIXME: for debug
 
 		select {
@@ -619,6 +620,7 @@ func (s *Scenario) addCourseLoad(ctx context.Context, step *isucandar.BenchmarkS
 
 	course := model.NewCourse(courseParam, addCourseRes.ID, teacher)
 	s.AddCourse(course)
+	s.AddRegistrableCourses(course)
 	s.emptyCourseManager.AddEmptyCourse(course)
 	s.cPubSub.Publish(course)
 }

--- a/benchmarker/scenario/scenario.go
+++ b/benchmarker/scenario/scenario.go
@@ -24,6 +24,7 @@ type Scenario struct {
 	sPubSub             *pubsub.PubSub
 	cPubSub             *pubsub.PubSub
 	courses             map[string]*model.Course
+	registrableCourses  map[string]*model.Course
 	emptyCourseManager  *util.CourseManager
 	faculties           []*model.Teacher
 	studentPool         *userPool
@@ -61,6 +62,7 @@ func NewScenario(config *Config) (*Scenario, error) {
 		sPubSub:            pubsub.NewPubSub(),
 		cPubSub:            pubsub.NewPubSub(),
 		courses:            map[string]*model.Course{},
+		registrableCourses: map[string]*model.Course{},
 		emptyCourseManager: util.NewCourseManager(),
 		faculties:          faculties,
 		studentPool:        NewUserPool(studentsData),
@@ -72,6 +74,12 @@ func (s *Scenario) Language() string {
 	return s.language
 }
 
+func (s *Scenario) ActiveStudent() []*model.Student {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.activeStudents
+}
 func (s *Scenario) AddActiveStudent(student *model.Student) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -103,6 +111,27 @@ func (s *Scenario) AddCourse(course *model.Course) {
 	defer s.mu.Unlock()
 
 	s.courses[course.ID] = course
+}
+
+func (s *Scenario) AddRegistrableCourses(course *model.Course) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.registrableCourses[course.ID] = course
+}
+
+func (s *Scenario) RemoveRegistrableCourses(course *model.Course) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.registrableCourses, course.ID)
+}
+
+func (s *Scenario) RegistrableCourses() map[string]*model.Course {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.registrableCourses
 }
 
 func (s *Scenario) GetCourse(id string) (*model.Course, bool) {

--- a/benchmarker/scenario/validation.go
+++ b/benchmarker/scenario/validation.go
@@ -2,8 +2,11 @@ package scenario
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/isucon/isucandar"
+	"github.com/isucon/isucandar/failure"
+	"github.com/isucon/isucon11-final/benchmarker/fails"
 )
 
 func (s *Scenario) Validation(ctx context.Context, step *isucandar.BenchmarkStep) error {
@@ -14,6 +17,7 @@ func (s *Scenario) Validation(ctx context.Context, step *isucandar.BenchmarkStep
 
 	s.validateAnnouncements(ctx, step)
 	s.validateCourses(ctx, step)
+	s.validateEmptyCourses(ctx, step)
 	s.validateGrades(ctx, step)
 
 	return nil
@@ -25,6 +29,58 @@ func (s *Scenario) validateAnnouncements(ctx context.Context, step *isucandar.Be
 
 func (s *Scenario) validateCourses(ctx context.Context, step *isucandar.BenchmarkStep) {
 
+	return
+}
+
+func (s *Scenario) validateEmptyCourses(ctx context.Context, step *isucandar.BenchmarkStep) {
+	errNotMatchCount := failure.NewError(fails.ErrCritical, fmt.Errorf("最終検証にて登録されている Course の個数が一致しませんでした"))
+	errNotMatch := failure.NewError(fails.ErrCritical, fmt.Errorf("最終検証にて存在しないはずの Course が見つかりました"))
+
+	students := s.ActiveStudent()
+	expectCourses := s.RegistrableCourses()
+
+	if len(students) == 0 || len(expectCourses) == 0 {
+		return
+	}
+
+	// searchAPIを叩くユーザ
+	student := students[0]
+
+	_, err := LoginAction(ctx, student.Agent, student.UserAccount)
+	if err != nil {
+		step.AddError(failure.NewError(fails.ErrCritical, err))
+		return
+	}
+
+	var actualCourseIDs []string
+	// 空検索パラメータで全部ページング → 履修可能なコースをすべて集める
+	nextPathParam := "/api/syllabus"
+	for nextPathParam != "" {
+		hres, res, err := SearchCourseAction(ctx, student.Agent, nil, nextPathParam)
+		if err != nil {
+			step.AddError(failure.NewError(fails.ErrCritical, err))
+			return
+		}
+		for _, c := range res {
+			actualCourseIDs = append(actualCourseIDs, c.ID.String())
+		}
+
+		_, nextPathParam = parseLinkHeader(hres)
+	}
+
+	if len(expectCourses) != len(actualCourseIDs) {
+		step.AddError(errNotMatchCount)
+		return
+	}
+
+	// IDによる存在チェックのみ
+	// 中身の検証はLoadでしているので省略
+	for _, id := range actualCourseIDs {
+		if expectCourses[id] != nil {
+			step.AddError(errNotMatch)
+			return
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
登録されたコースのうち`/search`で取得できるコース(履修締め切ってないやつ)の検証
emptyCourseManagerだと内部的に履修を締め切ったコースを保持してないのでScenarioにあたらしくもたせるようにした

Loadのリクエストを終わらせるPRを混ぜて動作確認できたらWIP外す