### PR TITLE
ベンチmemprof追加

### DIFF
--- a/benchmarker/go.mod
+++ b/benchmarker/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/isucon/isucandar v0.0.0-20210516110136-4274ebbe6701
 	github.com/isucon/isucon10-portal v0.0.0-20201008112716-8c0b637e1bd8
 	github.com/pborman/uuid v1.2.1
+	github.com/pkg/profile v1.6.0
 )

--- a/benchmarker/go.sum
+++ b/benchmarker/go.sum
@@ -52,6 +52,8 @@ github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=
+github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20200819021114-67c6ae64274f h1:JDEmUDtyiLMyMlFwiaDOv2hxUp35497fkwePcLeV7j4=


### PR DESCRIPTION
たぶんメモリの問題は全くなさそうだけど予選でもいれたのでこっちにも移植

```
./ benchmarker -mem-profile memprof
```
上記オプションをつけることでベンチ実行中にプロセスがメモリを確保した際
memprof/mem.profとしてprofileを吐くようにしました。（追加で確保するごとに上書き）

profileは以下で確認
```
go tool pprof memprof/mem.pprof
```