### PR TITLE
お知らせ追加のHTTP response status修正

### DIFF
--- a/webapp/golang/main.go
+++ b/webapp/golang/main.go
@@ -1522,13 +1522,12 @@ func (h *handlers) AddAnnouncement(c echo.Context) error {
 	}
 	defer tx.Rollback()
 
-	var announcementCount int
-	if err := tx.Get(&announcementCount, "SELECT COUNT(*) FROM `announcements` WHERE `course_id` = ? AND `title` = ? AND `message` = ? AND `created_at` = ?", req.CourseID, req.Title, req.Message, req.CreatedAt); err != nil {
+	var existingAnnouncementID uuid.UUID
+	if err := tx.Get(&existingAnnouncementID, "SELECT `id` FROM `announcements` WHERE `course_id` = ? AND `title` = ? AND `message` = ? AND `created_at` = ?", req.CourseID, req.Title, req.Message, req.CreatedAt); err != nil && err != sql.ErrNoRows {
 		c.Logger().Error(err)
 		return c.NoContent(http.StatusInternalServerError)
-	}
-	if announcementCount > 0 {
-		return echo.NewHTTPError(http.StatusCreated, "The same announcement already exists.")
+	} else if err == nil {
+		return c.JSON(http.StatusCreated, AddAnnouncementResponse{ID: existingAnnouncementID})
 	}
 
 	announcementID := uuid.NewRandom()


### PR DESCRIPTION
8/27のもくもく会で話した結果を反映
https://scrapbox.io/ISUCON11/%E6%9C%AC%E9%81%B8%E3%83%99%E3%83%B3%E3%83%81_%E7%9B%B8%E8%AB%87%E4%BA%8B%E9%A0%85#6128b7be14f75700006029bd

今は同じお知らせを追加すると `409` だけど `201` にした