### PR TITLE
コースのtimeslotを一様に分散させる

### DIFF
--- a/benchmarker/generate/course.go
+++ b/benchmarker/generate/course.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/isucon/isucon11-final/benchmarker/model"
@@ -63,7 +64,40 @@ func courseDescription() string {
 	return randElt(courseDescription1) + randElt(courseDescription2)
 }
 
-func majorCourseParam(teacher *model.Teacher) *model.CourseParam {
+var (
+	courseGenerator = NewCourseGenerator()
+)
+
+type CourseGenerator struct {
+	randTimeslots []int
+	next          int
+	mu            sync.Mutex
+}
+
+func NewCourseGenerator() *CourseGenerator {
+	return &CourseGenerator{
+		randTimeslots: ShuffledInts(30),
+		next:          0,
+		mu:            sync.Mutex{},
+	}
+}
+
+func (cg *CourseGenerator) nextTimeslot() (dayOfWeek int, period int) {
+	cg.mu.Lock()
+	defer cg.mu.Unlock()
+
+	nextTimeslot := cg.randTimeslots[cg.next]
+	dayOfWeek = nextTimeslot/6 + 1
+	period = nextTimeslot % 6
+	cg.next++
+	if cg.next == 30 {
+		cg.randTimeslots = ShuffledInts(30)
+		cg.next = 0
+	}
+	return
+}
+
+func (cg *CourseGenerator) majorCourseParam(teacher *model.Teacher) *model.CourseParam {
 	code := atomic.AddInt32(&majorCode, 1)
 
 	var (
@@ -85,6 +119,7 @@ func majorCourseParam(teacher *model.Teacher) *model.CourseParam {
 
 	name.WriteString(randElt(majorSuffix))
 
+	dayOfWeek, period := cg.nextTimeslot()
 	return &model.CourseParam{
 		Code:        fmt.Sprintf("M%04d", code), // 重複不可, L,M+4桁の数字
 		Type:        "major-subjects",
@@ -92,13 +127,13 @@ func majorCourseParam(teacher *model.Teacher) *model.CourseParam {
 		Description: courseDescription(),
 		Credit:      rand.Intn(3) + 1, // 1-3
 		Teacher:     teacher.Name,
-		Period:      rand.Intn(6),     // いいカンジに分散
-		DayOfWeek:   rand.Intn(5) + 1, // いいカンジに分散
+		Period:      period,
+		DayOfWeek:   dayOfWeek,
 		Keywords:    strings.Join(keywords, " "),
 	}
 }
 
-func liberalCourseParam(teacher *model.Teacher) *model.CourseParam {
+func (cg *CourseGenerator) liberalCourseParam(teacher *model.Teacher) *model.CourseParam {
 	code := atomic.AddInt32(&liberalCode, 1)
 
 	var (
@@ -116,6 +151,7 @@ func liberalCourseParam(teacher *model.Teacher) *model.CourseParam {
 
 	name.WriteString(randElt(liberalSuffix))
 
+	dayOfWeek, period := cg.nextTimeslot()
 	return &model.CourseParam{
 		Code:        fmt.Sprintf("L%04d", code), // 重複不可, L,M+4桁の数字
 		Type:        "liberal-arts",
@@ -123,17 +159,17 @@ func liberalCourseParam(teacher *model.Teacher) *model.CourseParam {
 		Description: courseDescription(),
 		Credit:      rand.Intn(3) + 1, // 1-3
 		Teacher:     teacher.Name,
-		Period:      rand.Intn(6),     // いいカンジに分散
-		DayOfWeek:   rand.Intn(5) + 1, // いいカンジに分散
+		Period:      period,
+		DayOfWeek:   dayOfWeek,
 		Keywords:    strings.Join(keywords, " "),
 	}
 }
 
 func CourseParam(teacher *model.Teacher) *model.CourseParam {
 	if rand.Float64() < majorCourseProb {
-		return majorCourseParam(teacher)
+		return courseGenerator.majorCourseParam(teacher)
 	} else {
-		return liberalCourseParam(teacher)
+		return courseGenerator.liberalCourseParam(teacher)
 	}
 }
 

--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -404,7 +404,7 @@ func (s *Scenario) createLoadCourseWorker(ctx context.Context, step *isucandar.B
 			return
 		}
 
-		DebugLogger.Println(course.Name, "のタスクが追加された") // FIXME: for debug
+		DebugLogger.Printf("[コース追加] code: %v, name: %v", course.Code, course.Name)
 		loadCourseWorker.Do(courseScenario(course, step, s))
 	})
 	return loadCourseWorker


### PR DESCRIPTION
Courseを生成するときのDayofWeekとPeriodを完全ランダムではなく、一様に分散するようにしました。

- course.goがごちゃついてしまったのでいい感じのまとめ方があれば教えてください。
- DebugLoggerを無機質な感じのメッセージにしてるのは趣味です。

close #426 