### PR TITLE
課題提出の修正

### DIFF
--- a/benchmarker/scenario/verify.go
+++ b/benchmarker/scenario/verify.go
@@ -480,12 +480,13 @@ func verifyAssignments(assignmentsData []byte, class *model.Class) error {
 			return errInvalidResponse("課題zipに含まれるファイルの数が期待する値と一致しません")
 		}
 
-		for studentCode, summary := range class.Submissions() {
-			checksumDownloaded, ok := downloadedAssignments[studentCode+".pdf"]
+		for studentCode, submission := range class.Submissions() {
+			expectedFileName := studentCode + "-" + submission.Title
+			checksumDownloaded, ok := downloadedAssignments[expectedFileName]
 			if !ok {
-				return errInvalidResponse("提出した課題が課題zipに含まれていません")
+				return errInvalidResponse("提出した課題が課題zipに含まれていないか、ファイル名が間違っています")
 			}
-			if summary.Checksum != checksumDownloaded {
+			if submission.Checksum != checksumDownloaded {
 				return errInvalidResponse("提出した課題とダウンロードされた課題の内容が一致しません")
 			}
 		}

--- a/webapp/golang/main.go
+++ b/webapp/golang/main.go
@@ -1146,7 +1146,7 @@ func (h *handlers) DownloadSubmittedAssignments(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 	var submissions []Submission
-	query := "SELECT `submissions`.`user_id`, `users`.`code` AS `user_code`" +
+	query := "SELECT `submissions`.`user_id`, `submissions`.`file_name`, `users`.`code` AS `user_code`" +
 		" FROM `submissions`" +
 		" JOIN `users` ON `users`.`id` = `submissions`.`user_id`" +
 		" WHERE `class_id` = ? FOR SHARE"
@@ -1188,7 +1188,7 @@ func createSubmissionsZip(zipFilePath string, classID string, submissions []Subm
 		if err := exec.Command(
 			"cp",
 			AssignmentsDirectory+classID+"-"+submission.UserID+".pdf",
-			tmpDir+submission.UserCode+".pdf",
+			tmpDir+submission.UserCode+"-"+submission.FileName,
 		).Run(); err != nil {
 			return err
 		}


### PR DESCRIPTION
- 保存時に、拡張子`.pdf`をつけるように
  - PDFじゃなくても
- ファイル名を無視するように
  - おもしろポイントとして残しても良かったけど、重複を考慮したりするとベンチの検証が面倒なのでなし