### PR TITLE
scoretagの出力を揃える

### DIFF
--- a/benchmarker/main.go
+++ b/benchmarker/main.go
@@ -130,19 +130,20 @@ func sendResult(s *scenario.Scenario, result *isucandar.BenchmarkResult, finish 
 
 	// 競技者には最終的なScoreTagの統計のみ見せる
 	if finish {
+		tagFormat := fmt.Sprintf("tag: %%-%ds : %%d", score.MaxTagLengthForContestant())
 		for _, tag := range score.ScoreTags {
 			// _ で始まるタグは競技者には見せない
 			if tag[0] == '_' {
 				continue
 			}
-
-			scenario.ContestantLogger.Printf("tag: %v: %v", tag, breakdown[tag])
+			scenario.ContestantLogger.Printf(tagFormat, tag, breakdown[tag])
 		}
 	}
 
 	if writeScoreToAdminLogger {
+		tagFormat := fmt.Sprintf("tag: %%-%ds : %%d", score.MaxTagLength())
 		for _, tag := range score.ScoreTags {
-			scenario.AdminLogger.Printf("tag: %v: %v", tag, breakdown[tag])
+			scenario.AdminLogger.Printf(tagFormat, tag, breakdown[tag])
 		}
 	}
 

--- a/benchmarker/score/score.go
+++ b/benchmarker/score/score.go
@@ -20,15 +20,15 @@ const (
 	CountAddAnnouncement              score.ScoreTag = "13.AddAnnouncement"
 	CountGetAnnouncementList          score.ScoreTag = "14.GetAnnouncementList"
 	CountGetAnnouncementsDetail       score.ScoreTag = "15.GetAnnouncementDetail"
-	CountActiveStudents               score.ScoreTag = "_1.ActiveStudents"
-	CountFinishCourses                score.ScoreTag = "_2.FinishCourses"
-	CountGetCourseDetailVerifySkipped score.ScoreTag = "_3.GetCourseDetailVerifySkipped"
-	CountStartCourseUnder10           score.ScoreTag = "_4.StartCourseUnder10"
-	CountStartCourseUnder20           score.ScoreTag = "_5.StartCourseUnder20"
-	CountStartCourseUnder30           score.ScoreTag = "_6.StartCourseUnder30"
-	CountStartCourseUnder40           score.ScoreTag = "_7.StartCourseUnder40"
-	CountStartCourseUnder50           score.ScoreTag = "_8.StartCourseUnder50"
-	CountStartCourseFull              score.ScoreTag = "_9.StartCourseFull"
+	CountActiveStudents               score.ScoreTag = "_01.ActiveStudents"
+	CountFinishCourses                score.ScoreTag = "_02.FinishCourses"
+	CountGetCourseDetailVerifySkipped score.ScoreTag = "_03.GetCourseDetailVerifySkipped"
+	CountStartCourseUnder10           score.ScoreTag = "_04.StartCourseUnder10"
+	CountStartCourseUnder20           score.ScoreTag = "_05.StartCourseUnder20"
+	CountStartCourseUnder30           score.ScoreTag = "_06.StartCourseUnder30"
+	CountStartCourseUnder40           score.ScoreTag = "_07.StartCourseUnder40"
+	CountStartCourseUnder50           score.ScoreTag = "_08.StartCourseUnder50"
+	CountStartCourseFull              score.ScoreTag = "_09.StartCourseFull"
 	CountStartCourseOver50            score.ScoreTag = "_10.StartCourseOver50"
 )
 
@@ -58,6 +58,26 @@ var ScoreTags = []score.ScoreTag{
 	CountStartCourseUnder50,
 	CountStartCourseFull,
 	CountStartCourseOver50,
+}
+
+func MaxTagLength() int {
+	maxLength := 0
+	for _, tag := range ScoreTags {
+		if len(tag) > maxLength {
+			maxLength = len(tag)
+		}
+	}
+	return maxLength
+}
+
+func MaxTagLengthForContestant() int {
+	maxLength := 0
+	for _, tag := range ScoreTags {
+		if tag[0] != '_' && len(tag) > maxLength {
+			maxLength = len(tag)
+		}
+	}
+	return maxLength
 }
 
 type mag int64      // 1回でn点


### PR DESCRIPTION
長いタグに合わせて左詰めしてみました。
```
11:56:26.267366 tag: 01.RegisterCourses         : 48
11:56:26.267372 tag: 02.GetRegisteredCourses    : 48
11:56:26.267378 tag: 03.GetGrades               : 317
11:56:26.267386 tag: 04.SearchCourses           : 3528
11:56:26.267392 tag: 05.GetCourseDetail         : 1168
11:56:26.267397 tag: 06.AddCourse               : 60
11:56:26.267402 tag: 07.AddClass                : 100
11:56:26.267407 tag: 08.GetClasses              : 999
11:56:26.267412 tag: 09.SubmitValidAssignment   : 924
11:56:26.267418 tag: 10.SubmitInvalidAssignment : 75
11:56:26.267423 tag: 11.DownloadSubmissions     : 100
11:56:26.267428 tag: 12.RegisterScore           : 200
11:56:26.267433 tag: 13.AddAnnouncement         : 100
11:56:26.267438 tag: 14.GetAnnouncementList     : 2531
11:56:26.267444 tag: 15.GetAnnouncementDetail   : 3693
```