### PR TITLE
要らない誤差の比較を消す

### DIFF
--- a/webapp/golang/util.go
+++ b/webapp/golang/util.go
@@ -84,15 +84,9 @@ func tScoreInt(v int, arr []int) float64 {
 
 // ----- float64 -----
 
-var epsilon = math.Nextafter(1, 2) - 1
-
-func isEqualFloat64(v1, v2 float64) bool {
-	return v1 == v2 || math.Abs(v1-v2)/math.Max(math.Abs(v1), math.Abs(v2)) <= epsilon
-}
-
 func isAllEqualFloat64(arr []float64) bool {
 	for _, v := range arr {
-		if !isEqualFloat64(arr[0], v) {
+		if arr[0] != v {
 			return false
 		}
 	}


### PR DESCRIPTION
これは消しても良い

一応理由: 前まで書いていたepsilon (machine epsilon 1つ分) での相対誤差の比較はほとんど意味が無いもの。入力値にも変な微妙な誤差が発生する可能性が無いと見て、isAllEqual判定で使っている相対誤差の比較自体を消す。