### PR TITLE
Teacherのログインは一度だけ

### DIFF
--- a/benchmarker/model/user.go
+++ b/benchmarker/model/user.go
@@ -220,8 +220,8 @@ func (s *Student) TotalCredit() int {
 
 type Teacher struct {
 	*UserAccount
-	Agent   *agent.Agent
-	IsLogin bool
+	Agent      *agent.Agent
+	IsLoggedIn bool
 
 	mu sync.Mutex
 }
@@ -238,14 +238,14 @@ func NewTeacher(userData *UserAccount, baseURL *url.URL) *Teacher {
 	}
 }
 
-func (t *Teacher) LoginAtOnce(f func(teacher *Teacher)) bool {
+func (t *Teacher) LoginOnce(f func(teacher *Teacher)) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if t.IsLogin {
+	if t.IsLoggedIn {
 		return true
 	}
 	f(t)
 
-	return t.IsLogin
+	return t.IsLoggedIn
 }

--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -682,15 +682,15 @@ func (s *Scenario) addCourseLoad(ctx context.Context, step *isucandar.BenchmarkS
 		return
 	}
 
-	isLogin := teacher.LoginAtOnce(func(teacher *model.Teacher) {
+	isLoggedIn := teacher.LoginOnce(func(teacher *model.Teacher) {
 		_, err := LoginAction(ctx, teacher.Agent, teacher.UserAccount)
 		if err != nil {
 			step.AddError(err)
 			return
 		}
-		teacher.IsLogin = true
+		teacher.IsLoggedIn = true
 	})
-	if !isLogin {
+	if !isLoggedIn {
 		// ログインに失敗したらコース追加中断
 		return
 	}


### PR DESCRIPTION
Load中にTeacherのログインって負荷が高い終盤でも発生する可能性があるためErrCriticalはやめました

Onceだとログイン失敗時のハンドリングができなさそうなので今の実装になりました。
もっとよい方法あればおしえてください