### PR TITLE
Add authorized_keys for isucon-admin

### DIFF
--- a/provisioning/ansible/roles/common/tasks/main.yml
+++ b/provisioning/ansible/roles/common/tasks/main.yml
@@ -35,6 +35,22 @@
     state: present
     system: no
 
+- name: "Create /home/isucon-admin/.ssh directory"
+  file:
+    path: /home/isucon-admin/.ssh
+    state: directory
+    owner: isucon-admin
+    group: isucon-admin
+    mode: 0700
+
+- name: "Add isucon-admin authorized_keys"
+  copy:
+    content: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKq/L7EBVcP00sWi1Z4uAo4K9ToLiI59CbknMDtmXj2o isucon-admin@isucon11-final\n"
+    dest: /home/isucon-admin/.ssh/authorized_keys
+    owner: isucon-admin
+    group: isucon-admin
+    mode: 0600
+
 - name: "Add sudoers"
   copy:
     content: |


### PR DESCRIPTION
isucon-admin ユーザーに公開鍵を登録します

鍵は新たに生成したもので、ポータルの Admin パスをパスフレーズとしていて box 経由で共有します