### PR TITLE
事前解答用インフラの作成

### DIFF
--- a/provisioning/terraform-pre/.gitignore
+++ b/provisioning/terraform-pre/.gitignore
@@ -1,0 +1,1 @@
+/.terraform

--- a/provisioning/terraform-pre/.terraform.lock.hcl
+++ b/provisioning/terraform-pre/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.55.0"
+  hashes = [
+    "h1:Ls8MD4Olzybw9n0mP5Lr1S2PnZzlSKrpxvYN9u2p/dM=",
+    "zh:1795562df65e9e5a604c90fac17ab1a706bc398b38271a11bc43565d45532595",
+    "zh:266fd71ace988b5fecd72dae5f2f503e953a4d2ea51d8d490d22d1218b1407dc",
+    "zh:4b2daf1038352fb33df40a2bf9033f66383bb1f6509df70da08f86f4539df9f3",
+    "zh:59fa40d453baa15cee845fd62d8c807fc4d5204a5560ee7e54ebeef3a3143404",
+    "zh:5ad9f515354c654d53849d1193ee56e335b3b9cf8e8cbfa98479114e87089cc3",
+    "zh:69c3ebd945ce747e0b30315656bc8b4aec2f2486013c2a78d04890bff96d137d",
+    "zh:6bdb22a77b4d85b6d9f2403bce23d6c3c932dadd7c7541395cbbd51ec101842e",
+    "zh:7d5ba001be98432d6a1d385679a720cf0d6e6c0b1ee7d45384d2d6213e262b21",
+    "zh:ce4b85f470605c5cd24f8acfe05c6546d962a32ecf69a61034f0884c2e79fbcf",
+    "zh:d0b20e4e9e877279520162b7979e9cb8aa961cf06fb37d9f3e4ac7023c177545",
+    "zh:e029951f18e9dadd8929dddc752a5b354a4c9956b8ec1b67f4db7bc641199d22",
+  ]
+}

--- a/provisioning/terraform-pre/aws.tf
+++ b/provisioning/terraform-pre/aws.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region              = "ap-northeast-1"
+  allowed_account_ids = ["245943874622"]
+
+  default_tags {
+    tags = {
+      Project = "final-pre"
+    }
+  }
+}

--- a/provisioning/terraform-pre/backend.tf
+++ b/provisioning/terraform-pre/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket               = "isucon11-misc"
+    workspace_key_prefix = "terraform"
+    key                  = "terraform/final-pre.tfstate"
+    region               = "ap-northeast-1"
+    dynamodb_table       = "isucon11-terraform-locks"
+  }
+}

--- a/provisioning/terraform-pre/bench-user-data.sh.tpl
+++ b/provisioning/terraform-pre/bench-user-data.sh.tpl
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cat << _EOF_ >> /home/isucon/isuxportal-supervisor.env
+ISUXPORTAL_SUPERVISOR_INSTANCE_NAME=$(curl -s --retry 5 --retry-connrefused --max-time 10 --connect-timeout 5 http://169.254.169.254/latest/meta-data/local-ipv4)
+ISUXPORTAL_SUPERVISOR_ENDPOINT_URL=https://isuxportal-pre-grpc.xi.isucon.dev
+ISUXPORTAL_SUPERVISOR_TOKEN=${isuxportal_supervisor_token}
+ISUXPORTAL_SUPERVISOR_TEAM_ID=${isuxportal_supervisor_team_id}
+_EOF_
+chown isucon: /home/isucon/isuxportal-supervisor.env

--- a/provisioning/terraform-pre/bench.tf
+++ b/provisioning/terraform-pre/bench.tf
@@ -1,0 +1,49 @@
+data "aws_ami" "bench" {
+  owners      = ["self"]
+  most_recent = true
+  name_regex  = "^isucon11f-amd64-bench-\\d{8}-\\d{4}-[0-9a-f]{40}$"
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_ssm_parameter" "bench_token" {
+  name = "/hako/isuxportal-pre/ISUXPORTAL_BENCH_TOKEN"
+}
+
+resource "aws_instance" "bench" {
+  for_each = toset(var.team_ids)
+
+  ami           = data.aws_ami.bench.id
+  instance_type = "c5.large"
+
+  subnet_id         = aws_subnet.bench.id
+  availability_zone = aws_subnet.bench.availability_zone
+  private_ip        = cidrhost(aws_subnet.bench.cidr_block, index(var.team_ids, each.key) + 101)
+
+  vpc_security_group_ids = [
+    aws_security_group.bench.id,
+  ]
+
+  tags = {
+    Name = format("final-pre-bench-%02d", tonumber(each.key))
+  }
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = "20"
+    tags = {
+      Name    = format("final-pre-bench-%02d", tonumber(each.key))
+      Project = "final-pre"
+    }
+  }
+
+  user_data = templatefile("${path.module}/bench-user-data.sh.tpl", { isuxportal_supervisor_token = data.aws_ssm_parameter.bench_token.value, isuxportal_supervisor_team_id = each.key })
+}

--- a/provisioning/terraform-pre/contestant-user-data.sh.tpl
+++ b/provisioning/terraform-pre/contestant-user-data.sh.tpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p ~isucon/.ssh
+curl --retry 5 --retry-connrefused --max-time 10 --connect-timeout 5 "https://pre-portal.xi.isucon.dev/api/ssh_public_keys?token=${checker_token}" > ~isucon/.ssh/authorized_keys
+chmod 0700 ~isucon/.ssh
+chmod 0600 ~isucon/.ssh/authorized_keys
+chown -R isucon:isucon ~isucon/.ssh

--- a/provisioning/terraform-pre/contestant_instances.tf
+++ b/provisioning/terraform-pre/contestant_instances.tf
@@ -1,0 +1,150 @@
+data "aws_ami" "contestant" {
+  owners      = ["self"]
+  most_recent = true
+  name_regex  = "^isucon11f-amd64-contestant-\\d{8}-\\d{4}-[0-9a-f]{40}$"
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "contestant-1" {
+  for_each = toset(var.team_ids)
+
+  ami           = data.aws_ami.contestant.id
+  instance_type = "c5.large"
+
+  subnet_id         = aws_subnet.contestant[each.key].id
+  availability_zone = aws_subnet.contestant[each.key].availability_zone
+  private_ip        = cidrhost(aws_subnet.contestant[each.key].cidr_block, 101)
+
+  vpc_security_group_ids = [
+    aws_security_group.contestant[each.key].id,
+  ]
+
+
+  tags = {
+    Name = format("final-pre-contestant-%02d-1", tonumber(each.key))
+
+    IsuconTeamID      = each.key
+    IsuconInstanceNum = "1"
+  }
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = "30"
+    tags = {
+      Name    = format("final-pre-contestant-%02d-1", tonumber(each.key))
+      Project = "final-pre"
+    }
+  }
+
+  user_data = templatefile("${path.module}/contestant-user-data.sh.tpl", { checker_token = var.checker_tokens[each.key] })
+}
+
+resource "aws_eip" "contestant-1" {
+  for_each = toset(var.team_ids)
+
+  vpc      = true
+  instance = aws_instance.contestant-1[each.key].id
+
+  tags = {
+    Name = format("final-pre-contestant-%02d-1", tonumber(each.key))
+  }
+}
+
+resource "aws_instance" "contestant-2" {
+  for_each = toset(var.team_ids)
+
+  ami           = data.aws_ami.contestant.id
+  instance_type = "c5.large"
+
+  subnet_id         = aws_subnet.contestant[each.key].id
+  availability_zone = aws_subnet.contestant[each.key].availability_zone
+  private_ip        = cidrhost(aws_subnet.contestant[each.key].cidr_block, 102)
+
+  vpc_security_group_ids = [
+    aws_security_group.contestant[each.key].id,
+  ]
+
+
+  tags = {
+    Name = format("final-pre-contestant-%02d-2", tonumber(each.key))
+
+    IsuconTeamID      = each.key
+    IsuconInstanceNum = "2"
+  }
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = "30"
+    tags = {
+      Name    = format("final-pre-contestant-%02d-2", tonumber(each.key))
+      Project = "final-pre"
+    }
+  }
+
+  user_data = templatefile("${path.module}/contestant-user-data.sh.tpl", { checker_token = var.checker_tokens[each.key] })
+}
+
+resource "aws_eip" "contestant-2" {
+  for_each = toset(var.team_ids)
+
+  vpc      = true
+  instance = aws_instance.contestant-2[each.key].id
+
+  tags = {
+    Name = format("final-pre-contestant-%02d-2", tonumber(each.key))
+  }
+}
+
+resource "aws_instance" "contestant-3" {
+  for_each = toset(var.team_ids)
+
+  ami           = data.aws_ami.contestant.id
+  instance_type = "c5.large"
+
+  subnet_id         = aws_subnet.contestant[each.key].id
+  availability_zone = aws_subnet.contestant[each.key].availability_zone
+  private_ip        = cidrhost(aws_subnet.contestant[each.key].cidr_block, 103)
+
+  vpc_security_group_ids = [
+    aws_security_group.contestant[each.key].id,
+  ]
+
+
+  tags = {
+    Name = format("final-pre-contestant-%02d-3", tonumber(each.key))
+
+    IsuconTeamID      = each.key
+    IsuconInstanceNum = "3"
+  }
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = "30"
+    tags = {
+      Name    = format("final-pre-contestant-%02d-3", tonumber(each.key))
+      Project = "final-pre"
+    }
+  }
+
+  user_data = templatefile("${path.module}/contestant-user-data.sh.tpl", { checker_token = var.checker_tokens[each.key] })
+}
+
+resource "aws_eip" "contestant-3" {
+  for_each = toset(var.team_ids)
+
+  vpc      = true
+  instance = aws_instance.contestant-3[each.key].id
+
+  tags = {
+    Name = format("final-pre-contestant-%02d-3", tonumber(each.key))
+  }
+}

--- a/provisioning/terraform-pre/data.tf
+++ b/provisioning/terraform-pre/data.tf
@@ -1,0 +1,11 @@
+variable "team_ids" {
+  type    = list(string)
+  default = [1]
+}
+
+variable "checker_tokens" {
+  type = map(string)
+  default = {
+    1 = "dummy"
+  }
+}

--- a/provisioning/terraform-pre/security_groups.tf
+++ b/provisioning/terraform-pre/security_groups.tf
@@ -1,0 +1,79 @@
+resource "aws_security_group" "bench" {
+  vpc_id      = aws_vpc.main.id
+  name        = "final-pre-bench"
+  description = "security group for final-pre benchmarker instances"
+}
+
+data "aws_security_group" "bastion" {
+  vpc_id = data.aws_vpc.portal.id
+  name   = "bastion"
+}
+
+resource "aws_security_group_rule" "bench-ingress-ssh" {
+  security_group_id        = aws_security_group.bench.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = data.aws_security_group.bastion.id
+}
+
+resource "aws_security_group_rule" "bench-egress-all" {
+  security_group_id = aws_security_group.bench.id
+  type              = "egress"
+  protocol          = "all"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group" "contestant" {
+  for_each    = toset(var.team_ids)
+  vpc_id      = aws_vpc.main.id
+  name        = format("final-pre-contestant-%02d", tonumber(each.key))
+  description = "security group for final-pre team #${each.key} contestant instances"
+}
+
+resource "aws_security_group_rule" "contestant-ingress-ssh" {
+  for_each = toset(var.team_ids)
+
+  security_group_id = aws_security_group.contestant[each.key].id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 22
+  to_port           = 22
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "contestant-ingress-benchmark" {
+  for_each = toset(var.team_ids)
+
+  security_group_id        = aws_security_group.contestant[each.key].id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 80
+  to_port                  = 80
+  source_security_group_id = aws_security_group.bench.id
+}
+
+resource "aws_security_group_rule" "contestant-ingress-contestant" {
+  for_each = toset(var.team_ids)
+
+  security_group_id        = aws_security_group.contestant[each.key].id
+  type                     = "ingress"
+  protocol                 = "all"
+  from_port                = 0
+  to_port                  = 0
+  source_security_group_id = aws_security_group.contestant[each.key].id
+}
+
+resource "aws_security_group_rule" "contestant-egress-all" {
+  for_each = toset(var.team_ids)
+
+  security_group_id = aws_security_group.contestant[each.key].id
+  type              = "egress"
+  protocol          = "all"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/provisioning/terraform-pre/vpc.tf
+++ b/provisioning/terraform-pre/vpc.tf
@@ -1,0 +1,78 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.14.0.0/17"
+
+  tags = {
+    Name = "final-pre"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+}
+
+###
+# Contestant
+###
+
+resource "aws_subnet" "contestant" {
+  for_each = toset(var.team_ids)
+
+  availability_zone       = "ap-northeast-1a"
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 7, index(var.team_ids, each.key) + 1)
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = format("final-pre-contestant-%02d", tonumber(each.key))
+  }
+}
+
+resource "aws_route_table" "contestant" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "final-pre-contestant"
+  }
+}
+resource "aws_route" "contestant-default" {
+  route_table_id         = aws_route_table.contestant.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.main.id
+}
+
+resource "aws_route_table_association" "contestant" {
+  for_each       = toset(var.team_ids)
+  subnet_id      = aws_subnet.contestant[each.key].id
+  route_table_id = aws_route_table.contestant.id
+}
+
+###
+# Benchmarker
+###
+
+resource "aws_subnet" "bench" {
+  availability_zone       = "ap-northeast-1a"
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 7, 0)
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "final-pre-bench"
+  }
+}
+
+resource "aws_route_table" "bench" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "final-pre-bench"
+  }
+}
+resource "aws_route" "bench-default" {
+  route_table_id         = aws_route_table.bench.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.main.id
+}
+
+resource "aws_route_table_association" "bench" {
+  subnet_id      = aws_subnet.bench.id
+  route_table_id = aws_route_table.bench.id
+}

--- a/provisioning/terraform-pre/vpc_peering.tf
+++ b/provisioning/terraform-pre/vpc_peering.tf
@@ -1,0 +1,43 @@
+data "aws_vpc" "portal" {
+  id = "vpc-04f36e0596c6daf7f"
+}
+
+data "aws_route_table" "portal-public" {
+  vpc_id = data.aws_vpc.portal.id
+  filter {
+    name   = "tag:Name"
+    values = ["isucon11-public"]
+  }
+}
+
+data "aws_route_table" "portal-private" {
+  vpc_id = data.aws_vpc.portal.id
+  filter {
+    name   = "tag:Name"
+    values = ["isucon11-private"]
+  }
+}
+
+resource "aws_vpc_peering_connection" "portal" {
+  vpc_id      = aws_vpc.main.id
+  peer_vpc_id = data.aws_vpc.portal.id
+  auto_accept = true
+}
+
+resource "aws_route" "bench-to-portal" {
+  route_table_id            = aws_route_table.bench.id
+  destination_cidr_block    = data.aws_vpc.portal.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.portal.id
+}
+
+resource "aws_route" "portal-public-to-main" {
+  route_table_id            = data.aws_route_table.portal-public.id
+  destination_cidr_block    = aws_vpc.main.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.portal.id
+}
+
+resource "aws_route" "portal-private-to-main" {
+  route_table_id            = data.aws_route_table.portal-private.id
+  destination_cidr_block    = aws_vpc.main.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.portal.id
+}


### PR DESCRIPTION
事前解答のために必要な AWS リソース一式を作成しました。
本番で作成予定の構成と同じになるようにしました。

以下は雑にまとめた構成の詳細

* 各チーム3選手インスタンスと1ベンチマーカー構成
* チーム数も少ないので複雑にならないように全チーム `ap-northeast-1a` 使用
* `10.14.0.0/24` の範囲はベンチマーカー用サブネットで、全チームのベンチマーカーはそのサブネットに置く
  * 1チーム目のベンチマーカーは `10.14.0.101`, 2チーム目は `10.14.0.102` ... のようになる
* 1チーム目は `10.14.1.0/24`, 2チーム目は `10.14.2.0/24` のようにチーム用サブネットを切った
  * 各インスタンスのアドレス第4オクテットは .101, .102, .103 になる
* ポータル側で作ってある VPC と Peering した
  * ベンチマーカーは Peering 経由で Internal ALB な gRPC サーバーにつなげる
  * チーム向けサブネットには別のルーティングテーブルを作成していて、そっちには Peering のルートを含めてないので選手インスタンスからポータル関連リソースには直接繋がらないようにした
  * セキュリティグループもあるので繋がっても大きな問題はないはずだけど念の為
* AMI は最新のものを使うようになっているが事前解答で使うコミットが確定すれば、それで固定予定
* チームID 1 だけ仮で書かれているが、チーム登録が行われて確定したら更新予定
* 選手インスタンスへの SSH 鍵はポータルからトークンを指定して取得される
  * ポータル側から各チームのトークン貰って、それを apply 時に指定予定