### PR TITLE
ValidationでActiveStudentのLoginActionを抜く

### DIFF
--- a/benchmarker/scenario/validation.go
+++ b/benchmarker/scenario/validation.go
@@ -159,12 +159,6 @@ func (s *Scenario) validateCourses(ctx context.Context, step *isucandar.Benchmar
 	// searchAPIを叩くユーザ
 	student := students[0]
 
-	_, err := LoginAction(ctx, student.Agent, student.UserAccount)
-	if err != nil {
-		step.AddError(failure.NewError(fails.ErrCritical, err))
-		return
-	}
-
 	var actuals []*api.GetCourseDetailResponse
 	// 空検索パラメータで全部ページング → 科目をすべて集める
 	nextPathParam := "/api/syllabus"


### PR DESCRIPTION
Scenario.ActiveStudentはログインに成功してから追加されるためLoginアクションは不要（やるならCookieClearすべきだった）
ユーザ的に別のセッションでやるとそれっぽい(？)かなと思ったけど、今考える感じでは今の所不要な気がするので削除