### PR TITLE
内容が重複したお知らせチェックの追加

### DIFF
--- a/benchmarker/scenario/validation.go
+++ b/benchmarker/scenario/validation.go
@@ -112,18 +112,13 @@ func (s *Scenario) validateAnnouncements(ctx context.Context, step *isucandar.Be
 			}
 
 			// actualの重複確認
-			var existCreatedAt []int64
+			existCreatedAt := make(map[int64]struct{}, len(actualAnnouncements))
 			for _, a := range actualAnnouncements {
-				if a.Unread {
-					actualUnreadCount++
+				if _, ok := existCreatedAt[a.CreatedAt]; ok {
+					step.AddError(errDuplicated)
+					return
 				}
-				for _, e := range existCreatedAt {
-					if a.CreatedAt == e {
-						step.AddError(errDuplicated)
-						return
-					}
-				}
-				existCreatedAt = append(existCreatedAt, a.CreatedAt)
+				existCreatedAt[a.CreatedAt] = struct{}{}
 			}
 
 			expectAnnouncements := student.Announcements()


### PR DESCRIPTION
おしらせ追加のリトライ時、適切な内容重複チェックが行われずに同じお知らせを追加できてしまっている状態が発生した
→ https://github.com/isucon/isucon11-final/issues/540
その検証を追加した