### PR TITLE
nginxの設定を変更

### DIFF
--- a/dev/nginx/default.conf
+++ b/dev/nginx/default.conf
@@ -25,5 +25,7 @@ server {
 
   location / {
     root /www/data;
+    index index.html;
+    try_files $uri $uri/index.html /index.html;
   }
 }

--- a/provisioning/ansible/roles/contestant/files/etc/nginx/sites-available/isucholar.conf
+++ b/provisioning/ansible/roles/contestant/files/etc/nginx/sites-available/isucholar.conf
@@ -25,5 +25,7 @@ server {
 
   location / {
     root /home/isucon/webapp/frontend/dist;
+    index index.html;
+    try_files $uri $uri/index.html /index.html
   }
 }


### PR DESCRIPTION
`index` はデフォルトが `index.html` なので無くても実際は影響ないです。
`try_files` がなかったので、リロードした際に対象のパスにアクセスできないことがありました。

VueやNuxtの設定についても書かれていたのに見逃し...

参考
静的ファイルで配信しているので vue での設定についてリンクを張っておきます (NuxtのほうはNode前提でした...)
https://cli.vuejs.org/guide/deployment.html#docker-nginx