### PR TITLE
CIで packer build する

### DIFF
--- a/.github/workflows/ci-packer.yaml
+++ b/.github/workflows/ci-packer.yaml
@@ -20,9 +20,6 @@ jobs:
         with:
           go-version: 1.16
       - uses: actions/checkout@v2
-      - name: Get source tag of git
-        id: get_source_tag
-        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
 #245

ほぼ予選の内容から持ってきて、`qualify` を `final` に置換したものになります。
(GitHub ActionsへのSecret設定はこのあとやります)

qualifyからの変更点
- 初期データ生成部分を削除
- 証明書・秘密鍵生成部分を削除
- ベンチと競技者インスタンス生成を `make build` でひとまとめに