### PR TITLE
初期データ読み込みにgo:embedを使う

### DIFF
--- a/benchmarker/generate/user.go
+++ b/benchmarker/generate/user.go
@@ -2,47 +2,39 @@ package generate
 
 import (
 	"bufio"
-	"os"
+	"bytes"
+	_ "embed"
 	"strings"
 
 	"github.com/isucon/isucon11-final/benchmarker/model"
 )
 
 var (
-	studentFile = "./generate/data/student.tsv"
-	teacherFile = "./generate/data/teacher.tsv"
+	//go:embed data/student.tsv
+	studentsData []byte
+	//go:embed data/teacher.tsv
+	teachersData []byte
 )
 
 func LoadStudentsData() ([]*model.UserAccount, error) {
-	return loadUserAccountData(studentFile)
+	return loadUserAccountData(studentsData)
 }
 
 func LoadTeachersData() ([]*model.UserAccount, error) {
-	return loadUserAccountData(teacherFile)
+	return loadUserAccountData(teachersData)
 }
 
-func loadUserAccountData(path string) ([]*model.UserAccount, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
+func loadUserAccountData(data []byte) ([]*model.UserAccount, error) {
 	userDataSet := make([]*model.UserAccount, 0)
-	s := bufio.NewScanner(file)
-	for i := 0; s.Scan(); i++ {
+	s := bufio.NewScanner(bytes.NewReader(data))
+	for s.Scan() {
 		line := strings.Split(s.Text(), "\t")
-		code := line[0]
-		name := line[1]
-		rawPW := line[2]
-
 		account := &model.UserAccount{
-			Code:        code,
-			Name:        name,
-			RawPassword: rawPW,
+			Code:        line[0],
+			Name:        line[1],
+			RawPassword: line[2],
 		}
 		userDataSet = append(userDataSet, account)
 	}
-
 	return userDataSet, nil
 }


### PR DESCRIPTION
初期データを更新した際、ベンチの差し替え時に初期データファイル(.tsv)も置き換える必要があった
面倒なのでgo:embedでバイナリにデータを埋め込む

データはメモリの静的領域に残るけどいまのところメモリの心配はまったくないので良しとする
（260k点でsystemが420MBくらい）