### PR TITLE
ベンチでUUID以外を許容する

### DIFF
--- a/benchmarker/api/announcement.go
+++ b/benchmarker/api/announcement.go
@@ -11,7 +11,6 @@ import (
 	"github.com/isucon/isucandar/agent"
 	"github.com/isucon/isucandar/failure"
 	"github.com/isucon/isucon11-final/benchmarker/fails"
-	"github.com/pborman/uuid"
 )
 
 type AddAnnouncementRequest struct {
@@ -54,15 +53,15 @@ type GetAnnouncementsResponse struct {
 	Announcements []AnnouncementResponse `json:"announcements"`
 }
 
-func GetAnnouncementList(ctx context.Context, a *agent.Agent, rawURL string, courseID uuid.UUID) (*http.Response, error) {
+func GetAnnouncementList(ctx context.Context, a *agent.Agent, rawURL string, courseID string) (*http.Response, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, failure.NewError(fails.ErrHTTP, err)
 	}
 	q := u.Query()
 
-	if courseID != nil {
-		q.Set("course_id", courseID.String())
+	if courseID != "" {
+		q.Set("course_id", courseID)
 		u.RawQuery = q.Encode()
 	}
 

--- a/benchmarker/api/course.go
+++ b/benchmarker/api/course.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/isucon/isucandar/agent"
 	"github.com/isucon/isucandar/failure"
-	"github.com/pborman/uuid"
 
 	"github.com/isucon/isucon11-final/benchmarker/fails"
 )
@@ -28,7 +27,7 @@ type SearchCourseRequest struct {
 }
 
 type GetCourseDetailResponse struct {
-	ID          uuid.UUID  `json:"id"`
+	ID          string     `json:"id"`
 	Code        string     `json:"code"`
 	Type        CourseType `json:"type"`
 	Name        string     `json:"name"`

--- a/benchmarker/api/user.go
+++ b/benchmarker/api/user.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/isucon/isucandar/agent"
 	"github.com/isucon/isucandar/failure"
-	"github.com/pborman/uuid"
 
 	"github.com/isucon/isucon11-final/benchmarker/fails"
 )
@@ -41,7 +40,7 @@ var DayOfWeekTable = []DayOfWeek{
 }
 
 type GetRegisteredCourseResponseContent struct {
-	ID        uuid.UUID `json:"id"`
+	ID        string    `json:"id"`
 	Name      string    `json:"name"`
 	Teacher   string    `json:"teacher"`
 	Period    uint8     `json:"period"`

--- a/benchmarker/scenario/action.go
+++ b/benchmarker/scenario/action.go
@@ -230,7 +230,7 @@ func GetAnnouncementListAction(ctx context.Context, agent *agent.Agent, next str
 	if next == "" {
 		next = "/api/announcements"
 	}
-	hres, err := api.GetAnnouncementList(ctx, agent, next, nil)
+	hres, err := api.GetAnnouncementList(ctx, agent, next, "")
 	if err != nil {
 		return hres, res, failure.NewError(fails.ErrHTTP, err)
 	}

--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -241,7 +241,7 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 					step.AddScore(score.SearchCourses)
 
 					if len(res) > 0 {
-						checkTargetID = res[0].ID.String()
+						checkTargetID = res[0].ID
 					}
 
 					// Linkヘッダから次ページのPath + QueryParamを取得
@@ -260,7 +260,7 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 						step.AddError(err)
 						continue
 					}
-					expected, exists := s.CourseManager.GetCourseByID(res.ID.String())
+					expected, exists := s.CourseManager.GetCourseByID(res.ID)
 					// ベンチ側の登録がまだの場合は検証スキップ
 					if exists {
 						if err := verifyCourseDetail(&res, expected); err != nil {

--- a/benchmarker/scenario/validation.go
+++ b/benchmarker/scenario/validation.go
@@ -205,13 +205,13 @@ func (s *Scenario) validateCourses(ctx context.Context, step *isucandar.Benchmar
 	}
 
 	for _, actual := range actuals {
-		expect, ok := expectCourses[actual.ID.String()]
+		expect, ok := expectCourses[actual.ID]
 		if !ok {
 			step.AddError(errNotMatch)
 			return
 		}
 
-		if !AssertEqual("course ID", expect.ID, actual.ID.String()) ||
+		if !AssertEqual("course ID", expect.ID, actual.ID) ||
 			!AssertEqual("course Code", expect.Code, actual.Code) ||
 			!AssertEqual("course Name", expect.Name, actual.Name) ||
 			!AssertEqual("course Type", api.CourseType(expect.Type), actual.Type) ||

--- a/benchmarker/scenario/verify.go
+++ b/benchmarker/scenario/verify.go
@@ -178,7 +178,7 @@ func verifyClassScores(expected *model.SimpleClassScore, res *api.ClassScore) er
 }
 
 func verifyRegisteredCourse(actual *api.GetRegisteredCourseResponseContent, expected *model.Course) error {
-	if actual.ID.String() != expected.ID {
+	if actual.ID != expected.ID {
 		return errInvalidResponse("コースのIDが期待する値と一致しません")
 	}
 


### PR DESCRIPTION
webappがIDの形式を変えてもベンチは許容するように修正
prepareで適当なIDとして使っているのは後でULIDに直す

close #616