### PR TITLE
開発環境に prometheus 導入

### DIFF
--- a/provisioning/ansible/roles/bench.supervisor/files/etc/systemd/system/isuxportal-supervisor.service
+++ b/provisioning/ansible/roles/bench.supervisor/files/etc/systemd/system/isuxportal-supervisor.service
@@ -5,7 +5,7 @@ After=network.target cloud-config.service
 [Service]
 # 基本設定
 User=isucon
-ExecStart=/home/isucon/bin/isuxportal-supervisor /home/isucon/benchmarker/bin/benchmarker
+ExecStart=/home/isucon/bin/isuxportal-supervisor /home/isucon/benchmarker/bin/benchmarker -prom-out /run/prometheus-node-exporter/textfile/bench.prom
 WorkingDirectory=/home/isucon/benchmarker
 LogsDirectory=isuxportal-supervisor
 LimitNOFILE=2000000

--- a/provisioning/terraform-dev/bench.tf
+++ b/provisioning/terraform-dev/bench.tf
@@ -35,6 +35,7 @@ resource "aws_instance" "bench" {
 
   tags = {
     Name = format("final-dev-bench-%02d", count.index + 1)
+    Role = "bench"
   }
 
   root_block_device {
@@ -42,6 +43,7 @@ resource "aws_instance" "bench" {
     volume_size = "20"
     tags = {
       Name    = format("final-dev-bench-%02d", count.index + 1)
+      Role    = "bench"
       Project = "final-dev"
     }
   }

--- a/provisioning/terraform-dev/vpc.tf
+++ b/provisioning/terraform-dev/vpc.tf
@@ -78,3 +78,17 @@ resource "aws_security_group_rule" "final-dev-contestant-ingress-contestant" {
   to_port                  = 0
   source_security_group_id = aws_security_group.final-dev-contestant.id
 }
+
+data "aws_security_group" "prometheus" {
+  vpc_id = data.aws_vpc.main.id
+  name   = "prometheus"
+}
+
+resource "aws_security_group_rule" "final-dev-bench-ingress-prometheus" {
+  security_group_id        = aws_security_group.final-dev-bench.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 9100
+  to_port                  = 9100
+  source_security_group_id = data.aws_security_group.prometheus.id
+}


### PR DESCRIPTION
ベンチマーカーが prometheus によって監視されるようにします。
prometheus はポータル側が作成したものを使っており、 `Role` タグが `bench` のインスタンスを監視するようになっています。
そのために必要なタグとセキュリティグループの設定を追加しました。