### PR TITLE
ベンチのタグを見やすくする

### DIFF
--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -210,7 +210,8 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 				if err != nil {
 					step.AddError(err)
 				} else {
-					step.AddScore(score.GetGrades)
+					step.AddScore(score.ScoreGetGrades)
+					step.AddScore(score.RegGetGrades)
 				}
 			}
 
@@ -238,7 +239,7 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 						step.AddError(err)
 						continue
 					}
-					step.AddScore(score.SearchCourses)
+					step.AddScore(score.RegSearchCourses)
 
 					if len(res) > 0 {
 						checkTargetID = res[0].ID
@@ -266,10 +267,10 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 						if err := verifyCourseDetail(&res, expected); err != nil {
 							step.AddError(err)
 						} else {
-							step.AddScore(score.GetCourseDetail)
+							step.AddScore(score.RegGetCourseDetail)
 						}
 					} else {
-						step.AddScore(score.GetCourseDetailVerifySkipped)
+						step.AddScore(score.RegGetCourseDetailVerifySkipped)
 					}
 				}
 
@@ -290,7 +291,7 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 			if err := verifyRegisteredCourses(getRegisteredCoursesRes, registeredSchedule); err != nil {
 				step.AddError(err)
 			} else {
-				step.AddScore(score.GetRegisteredCourses)
+				step.AddScore(score.RegGetRegisteredCourses)
 			}
 
 			// ----------------------------------------
@@ -349,10 +350,10 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 				}
 			} else {
 				if !isExtendRequest {
-					step.AddScore(score.RegisterCourses)
+					step.AddScore(score.RegRegisterCourses)
 				}
 				for _, c := range temporaryReservedCourses {
-					step.AddScore(score.RegisterCourseByStudent)
+					step.AddScore(score.RegRegisterCourseByStudent)
 					c.CommitReservation(student)
 					student.AddCourse(c)
 					c.StartTimer(waitCourseFullTimeout)
@@ -390,7 +391,8 @@ func (s *Scenario) readAnnouncementScenario(student *model.Student, step *isucan
 			if err := verifyAnnouncementsList(&res, expectAnnouncementList, true); err != nil {
 				step.AddError(err)
 			} else {
-				step.AddScore(score.GetAnnouncementList)
+				step.AddScore(score.ScoreGetAnnouncementList)
+				step.AddScore(score.UnreadGetAnnouncementList)
 			}
 
 			// このページに存在する未読お知らせ数（ページングするかどうかの判定用）
@@ -432,6 +434,8 @@ func (s *Scenario) readAnnouncementScenario(student *model.Student, step *isucan
 					step.AddError(err)
 				} else {
 					step.AddScore(score.GetAnnouncementsDetail)
+					step.AddScore(score.UnreadGetAnnouncementDetail)
+
 				}
 
 				student.ReadAnnouncement(ans.ID)
@@ -487,7 +491,8 @@ func (s *Scenario) readAnnouncementPagingScenario(student *model.Student, step *
 			if err := verifyAnnouncementsList(&res, expectAnnounceList, false); err != nil {
 				step.AddError(err)
 			} else {
-				step.AddScore(score.GetAnnouncementList)
+				step.AddScore(score.ScoreGetAnnouncementList)
+				step.AddScore(score.PagingGetAnnouncementList)
 			}
 
 			// このページ内で既読のおしらせを集める
@@ -524,6 +529,7 @@ func (s *Scenario) readAnnouncementPagingScenario(student *model.Student, step *
 					step.AddError(err)
 				} else {
 					step.AddScore(score.GetAnnouncementsDetail)
+					step.AddScore(score.PagingGetAnnouncementDetail)
 				}
 			}
 
@@ -590,11 +596,11 @@ func (s *Scenario) courseScenario(course *model.Course, step *isucandar.Benchmar
 		studentLen := len(course.Students())
 		switch {
 		case studentLen < 50:
-			step.AddScore(score.StartCourseUnder50)
+			step.AddScore(score.CourseStartCourseUnder50)
 		case studentLen == 50:
-			step.AddScore(score.StartCourseFull)
+			step.AddScore(score.CourseStartCourseFull)
 		case studentLen > 50:
-			step.AddScore(score.StartCourseOver50)
+			step.AddScore(score.CourseStartCourseOver50)
 		}
 
 		var classTimes [ClassCountPerCourse]int64
@@ -634,7 +640,7 @@ func (s *Scenario) courseScenario(course *model.Course, step *isucandar.Benchmar
 				}
 			} else {
 				if !isExtendRequest {
-					step.AddScore(score.AddClass)
+					step.AddScore(score.CourseAddClass)
 				}
 			}
 			class := model.NewClass(classRes.ClassID, classParam)
@@ -670,7 +676,7 @@ func (s *Scenario) courseScenario(course *model.Course, step *isucandar.Benchmar
 			} else {
 				announcement.ID = ancRes.ID
 				if !isExtendRequest {
-					step.AddScore(score.AddAnnouncement)
+					step.AddScore(score.CourseAddAnnouncement)
 				}
 			}
 			course.BroadCastAnnouncement(announcement)
@@ -693,7 +699,7 @@ func (s *Scenario) courseScenario(course *model.Course, step *isucandar.Benchmar
 			if err := verifyAssignments(assignmentsData, class); err != nil {
 				step.AddError(err)
 			} else {
-				step.AddScore(score.DownloadSubmissions)
+				step.AddScore(score.CourseDownloadSubmissions)
 			}
 
 			if s.isNoRequestTime(ctx) {
@@ -892,7 +898,7 @@ L:
 		}
 	}
 	if !isExtendRequest {
-		step.AddScore(score.AddCourse)
+		step.AddScore(score.CourseAddCourse)
 	}
 
 	course := model.NewCourse(courseParam, addCourseRes.ID, teacher, StudentCapacityPerCourse)
@@ -938,7 +944,7 @@ func (s *Scenario) submitAssignments(ctx context.Context, students map[string]*m
 			if err := verifyClasses(res, course.Classes()); err != nil {
 				step.AddError(err)
 			} else {
-				step.AddScore(score.GetClasses)
+				step.AddScore(score.CourseGetClasses)
 			}
 
 			// 課題を提出する
@@ -968,7 +974,8 @@ func (s *Scenario) submitAssignments(ctx context.Context, students map[string]*m
 				}
 			} else {
 				if !isExtendRequest {
-					step.AddScore(score.SubmitAssignment)
+					step.AddScore(score.ScoreSubmitAssignment)
+					step.AddScore(score.CourseSubmitAssignment)
 				}
 				submission := model.NewSubmission(fileName, submissionData)
 				class.AddSubmission(student.Code, submission)
@@ -1033,7 +1040,7 @@ L:
 	}
 
 	if !isExtendRequest {
-		step.AddScore(score.RegisterScore)
+		step.AddScore(score.CourseRegisterScore)
 	}
 
 	// POST成功したスコアをベンチ内に保存する

--- a/benchmarker/score/calc.go
+++ b/benchmarker/score/calc.go
@@ -6,10 +6,10 @@ type mag int64      // 1回でn点
 type fraction int64 // n回で1点
 
 var scoreCoefTable = map[score.ScoreTag]interface{}{
-	SubmitAssignment: mag(5),
-	GetGrades:        mag(1),
+	ScoreSubmitAssignment: mag(5),
+	ScoreGetGrades:        mag(1),
 
-	GetAnnouncementList: fraction(2),
+	ScoreGetAnnouncementList: fraction(2),
 }
 
 var (

--- a/benchmarker/score/tags.go
+++ b/benchmarker/score/tags.go
@@ -3,57 +3,88 @@ package score
 import "github.com/isucon/isucandar/score"
 
 const (
-	SubmitAssignment    score.ScoreTag = "01.SubmitAssignment"
-	GetGrades           score.ScoreTag = "02.GetGrades"
-	GetAnnouncementList score.ScoreTag = "03.GetAnnouncementList"
+	// score
+	ScoreSubmitAssignment    score.ScoreTag = "SubmitAssignment"
+	ScoreGetGrades           score.ScoreTag = "GetGrades"
+	ScoreGetAnnouncementList score.ScoreTag = "GetAnnouncementList"
 
-	ActiveStudents               score.ScoreTag = "_01.ActiveStudents"
-	FinishCourses                score.ScoreTag = "_02.FinishCourses"
-	FinishCoursesStudents        score.ScoreTag = "_03.FinishCoursesStudents"
-	GetCourseDetailVerifySkipped score.ScoreTag = "_04.GetCourseDetailVerifySkipped"
-	StartCourseUnder50           score.ScoreTag = "_05.StartCourseUnder50"
-	StartCourseFull              score.ScoreTag = "_06.StartCourseFull"
-	RegisterCourses              score.ScoreTag = "_07.RegisterCourses"
-	GetRegisteredCourses         score.ScoreTag = "_08.GetRegisteredCourses"
-	SearchCourses                score.ScoreTag = "_09.SearchCourses"
-	GetCourseDetail              score.ScoreTag = "_10.GetCourseDetail"
-	AddCourse                    score.ScoreTag = "_11.AddCourse"
-	AddClass                     score.ScoreTag = "_12.AddClass"
-	GetClasses                   score.ScoreTag = "_13.GetClasses"
-	DownloadSubmissions          score.ScoreTag = "_14.DownloadSubmissions"
-	RegisterScore                score.ScoreTag = "_15.RegisterScore"
-	AddAnnouncement              score.ScoreTag = "_16.AddAnnouncement"
-	GetAnnouncementsDetail       score.ScoreTag = "_17.GetAnnouncementDetail"
-	RegisterCourseByStudent      score.ScoreTag = "_18.RegisterCourseByStudent"
+	// other
+	ActiveStudents           score.ScoreTag = "_O1.ActiveStudents"
+	FinishCourses            score.ScoreTag = "_O2.FinishCourses"
+	FinishCoursesStudents    score.ScoreTag = "_O3.FinishCoursesStudents"
+	GetAnnouncementsDetail   score.ScoreTag = "_O4.GetAnnouncementDetail"
+	CourseStartCourseUnder50 score.ScoreTag = "_O5.StartCourseUnder50"
+	CourseStartCourseFull    score.ScoreTag = "_O6.StartCourseFull"
+	CourseStartCourseOver50  score.ScoreTag = "!O7.StartCourseOver50"
 
-	StartCourseOver50 score.ScoreTag = "!01.StartCourseOver50"
+	// registration scenario
+	RegGetGrades                    score.ScoreTag = "_R1.GetGrades"
+	RegSearchCourses                score.ScoreTag = "_R2.SearchCourses"
+	RegGetCourseDetail              score.ScoreTag = "_R3.GetCourseDetail"
+	RegGetCourseDetailVerifySkipped score.ScoreTag = "_R4.GetCourseDetailVerifySkipped"
+	RegGetRegisteredCourses         score.ScoreTag = "_R5.GetRegisteredCourses"
+	RegRegisterCourses              score.ScoreTag = "_R6.RegisterCourses"
+	RegRegisterCourseByStudent      score.ScoreTag = "_R7.RegisterCourseByStudent"
+
+	// read announcement scenario
+	UnreadGetAnnouncementList   score.ScoreTag = "_U1.GetAnnouncementList"
+	UnreadGetAnnouncementDetail score.ScoreTag = "_U2.GetAnnouncementDetail"
+
+	// read announcement paging scenario
+	PagingGetAnnouncementList   score.ScoreTag = "_P1.GetAnnouncementList"
+	PagingGetAnnouncementDetail score.ScoreTag = "_P2.GetAnnouncementDetail"
+
+	// course scenario
+	CourseAddCourse           score.ScoreTag = "_C1.AddCourse"
+	CourseAddClass            score.ScoreTag = "_C2.AddClass"
+	CourseAddAnnouncement     score.ScoreTag = "_C3.AddAnnouncement"
+	CourseGetClasses          score.ScoreTag = "_C4.GetClasses"
+	CourseSubmitAssignment    score.ScoreTag = "_C5.SubmitAssignment"
+	CourseDownloadSubmissions score.ScoreTag = "_C6.DownloadSubmissions"
+	CourseRegisterScore       score.ScoreTag = "_C7.RegisterScore"
 )
 
 var Tags = []score.ScoreTag{
-	SubmitAssignment,
-	GetGrades,
-	GetAnnouncementList,
+	// score
+	ScoreSubmitAssignment,
+	ScoreGetGrades,
+	ScoreGetAnnouncementList,
 
+	// other
 	ActiveStudents,
 	FinishCourses,
 	FinishCoursesStudents,
-	GetCourseDetailVerifySkipped,
-	StartCourseUnder50,
-	StartCourseFull,
-	RegisterCourses,
-	GetRegisteredCourses,
-	SearchCourses,
-	GetCourseDetail,
-	AddCourse,
-	AddClass,
-	GetClasses,
-	DownloadSubmissions,
-	RegisterScore,
-	AddAnnouncement,
 	GetAnnouncementsDetail,
-	RegisterCourseByStudent,
 
-	StartCourseOver50,
+	// registration scenario
+	RegGetGrades,
+	RegSearchCourses,
+	RegGetCourseDetail,
+	RegGetCourseDetailVerifySkipped,
+	RegGetRegisteredCourses,
+	RegRegisterCourses,
+	RegRegisterCourseByStudent,
+
+	// read announcement scenario
+	UnreadGetAnnouncementList,
+	UnreadGetAnnouncementDetail,
+
+	// read announcement paging scenario
+	PagingGetAnnouncementList,
+	PagingGetAnnouncementDetail,
+
+	// course scenario
+	CourseAddCourse,
+	CourseAddClass,
+	CourseAddAnnouncement,
+	CourseGetClasses,
+	CourseSubmitAssignment,
+	CourseDownloadSubmissions,
+	CourseRegisterScore,
+
+	CourseStartCourseUnder50,
+	CourseStartCourseFull,
+	CourseStartCourseOver50,
 }
 
 var (


### PR DESCRIPTION
close #621

announcement list とかは複数のシナリオで叩かれていたので、score用のtagとシナリオ用のtagを分けました