### PR TITLE
競技者に見せるスコアタグのログを分かりやすくする

### DIFF
--- a/benchmarker/main.go
+++ b/benchmarker/main.go
@@ -132,14 +132,15 @@ func sendResult(s *scenario.Scenario, result *isucandar.BenchmarkResult, finish 
 		}
 	}
 
-	scenario.ContestantLogger.Printf("score: %d(%d - %d) : %s", totalScore, rawScore, deductScore, reason)
+	scenario.ContestantLogger.Printf("score: %d (= %d - %d) : %s", totalScore, rawScore, deductScore, reason)
 	scenario.ContestantLogger.Printf("deductionCount: %d, timeoutCount: %d", deductionCount, timeoutCount)
 
-	// 競技者には最終的なScoreTagの統計のみ見せる
+	// 競技者には最終的な raw score の内訳のみ見せる
 	if finish {
-		tagFormat := fmt.Sprintf("tag: %%-%ds : %%d", score.MaxTagLengthForContestant)
+		scenario.ContestantLogger.Printf("raw score (%d) breakdown:", rawScore)
+		tagFormat := fmt.Sprintf("%%-%ds : %%d 回 (%%d 点)", score.MaxTagLengthForContestant)
 		for _, tag := range score.TagsForContestant {
-			scenario.ContestantLogger.Printf(tagFormat, tag, scoreTable[tag])
+			scenario.ContestantLogger.Printf(tagFormat, tag, scoreTable[tag], rawBreakdown[tag])
 		}
 	}
 


### PR DESCRIPTION
プレ解答のフィードバックを思い出して、少し分かりやすくしました

- (前提) 競技者はベンチのソースはおろか、ベンチが何をやっているかは作問者に比べて圧倒的に分からない
- 「score tag」ってなんだってなる
- 初見でも分かるように出力してあげた方が良い、もう少し分かりやすいやり方があればまた変える
