### PR TITLE
ベンチの検証リファクタ

### DIFF
--- a/benchmarker/generate/user.go
+++ b/benchmarker/generate/user.go
@@ -17,14 +17,14 @@ var (
 )
 
 func LoadStudentsData() ([]*model.UserAccount, error) {
-	return loadUserAccountData(studentsData)
+	return loadUserAccountData(studentsData, false)
 }
 
 func LoadTeachersData() ([]*model.UserAccount, error) {
-	return loadUserAccountData(teachersData)
+	return loadUserAccountData(teachersData, true)
 }
 
-func loadUserAccountData(data []byte) ([]*model.UserAccount, error) {
+func loadUserAccountData(data []byte, isAdmin bool) ([]*model.UserAccount, error) {
 	userDataSet := make([]*model.UserAccount, 0)
 	s := bufio.NewScanner(bytes.NewReader(data))
 	for s.Scan() {
@@ -33,6 +33,7 @@ func loadUserAccountData(data []byte) ([]*model.UserAccount, error) {
 			Code:        line[0],
 			Name:        line[1],
 			RawPassword: line[2],
+			IsAdmin:     isAdmin,
 		}
 		userDataSet = append(userDataSet, account)
 	}

--- a/benchmarker/model/class.go
+++ b/benchmarker/model/class.go
@@ -52,13 +52,6 @@ func (c *Class) Submissions() map[string]*Submission {
 	return res
 }
 
-func (c *Class) GetSubmittedCount() int {
-	c.rmu.RLock()
-	defer c.rmu.RUnlock()
-
-	return len(c.submissions)
-}
-
 func (c *Class) IntoSimpleClassScore(userCode string) *SimpleClassScore {
 	c.rmu.RLock()
 	defer c.rmu.RUnlock()

--- a/benchmarker/model/user.go
+++ b/benchmarker/model/user.go
@@ -15,6 +15,7 @@ type UserAccount struct {
 	Code        string
 	Name        string
 	RawPassword string
+	IsAdmin     bool
 }
 
 type Student struct {

--- a/benchmarker/scenario/assert.go
+++ b/benchmarker/scenario/assert.go
@@ -1,6 +1,9 @@
 package scenario
 
-import "reflect"
+import (
+	"math"
+	"reflect"
+)
 
 func AssertEqual(msg string, expected interface{}, actual interface{}) bool {
 	r := assertEqual(expected, actual)
@@ -27,10 +30,26 @@ func assertEqual(expected interface{}, actual interface{}) bool {
 	return false
 }
 
+func AssertGreaterOrEqual(msg string, expectMin, actual int) bool {
+	r := expectMin <= actual
+	if !r {
+		AdminLogger.Printf("%s: expected: >= %d / actual: %d", msg, expectMin, actual)
+	}
+	return r
+}
+
 func AssertInRange(msg string, expectMin, expectMax, actual int) bool {
 	r := expectMin <= actual && actual <= expectMax
 	if !r {
 		AdminLogger.Printf("%s: expected: %d ~ %d / actual: %d", msg, expectMin, expectMax, actual)
+	}
+	return r
+}
+
+func AssertWithinTolerance(msg string, expect, actual, tolerance float64) bool {
+	r := math.Abs(expect-actual) <= tolerance
+	if !r {
+		AdminLogger.Printf("%s: expected: %f ± %.2f / actual: %f", msg, expect, tolerance, actual)
 	}
 	return r
 }

--- a/benchmarker/scenario/load.go
+++ b/benchmarker/scenario/load.go
@@ -264,7 +264,7 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 					expected, exists := s.CourseManager.GetCourseByID(res.ID)
 					// ベンチ側の登録がまだの場合は検証スキップ
 					if exists {
-						if err := verifyCourseDetail(&res, expected); err != nil {
+						if err := verifyCourseDetail(expected, &res); err != nil {
 							step.AddError(err)
 						} else {
 							step.AddScore(score.RegGetCourseDetail)
@@ -282,13 +282,13 @@ func (s *Scenario) registrationScenario(student *model.Student, step *isucandar.
 				return
 			}
 
-			registeredSchedule := student.RegisteredSchedule()
+			expected := student.RegisteredSchedule()
 			_, getRegisteredCoursesRes, err := GetRegisteredCoursesAction(ctx, student.Agent)
 			if err != nil {
 				step.AddError(err)
 				continue
 			}
-			if err := verifyRegisteredCourses(getRegisteredCoursesRes, registeredSchedule); err != nil {
+			if err := verifyRegisteredCourses(expected, getRegisteredCoursesRes); err != nil {
 				step.AddError(err)
 			} else {
 				step.AddScore(score.RegGetRegisteredCourses)
@@ -376,7 +376,7 @@ func (s *Scenario) readAnnouncementScenario(student *model.Student, step *isucan
 				return
 			}
 
-			expectAnnouncementList := student.AnnouncementsMap()
+			expectAnnouncementMap := student.AnnouncementsMap()
 
 			startGetAnnouncementList := time.Now()
 			// 学生はお知らせを確認し続ける
@@ -388,7 +388,7 @@ func (s *Scenario) readAnnouncementScenario(student *model.Student, step *isucan
 			}
 			s.debugData.AddInt("GetAnnouncementListTime", time.Since(startGetAnnouncementList).Milliseconds())
 
-			if err := verifyAnnouncementsList(&res, expectAnnouncementList, true); err != nil {
+			if err := verifyAnnouncementsList(expectAnnouncementMap, &res, true); err != nil {
 				step.AddError(err)
 			} else {
 				step.AddScore(score.ScoreGetAnnouncementList)
@@ -402,14 +402,14 @@ func (s *Scenario) readAnnouncementScenario(student *model.Student, step *isucan
 					unreadCount++
 				}
 
-				announcementStatus := student.GetAnnouncement(ans.ID)
-				if announcementStatus == nil {
+				expectStatus := student.GetAnnouncement(ans.ID)
+				if expectStatus == nil {
 					// webappでは認識されているが、ベンチではまだ認識されていないお知らせ
 					// load中には検証できないので既読化しない
 					continue
 				}
 				// 前にタイムアウトになってしまっていた場合、もしくはまだ見ていないお知らせの場合詳細を見に行く
-				if !(announcementStatus.Dirty || ans.Unread) {
+				if !(expectStatus.Dirty || ans.Unread) {
 					continue
 				}
 
@@ -430,7 +430,7 @@ func (s *Scenario) readAnnouncementScenario(student *model.Student, step *isucan
 				}
 				s.debugData.AddInt("GetAnnouncementDetailTime", time.Since(startGetAnnouncementDetail).Milliseconds())
 
-				if err := verifyAnnouncementDetail(&res, announcementStatus); err != nil {
+				if err := verifyAnnouncementDetail(expectStatus, &res); err != nil {
 					step.AddError(err)
 				} else {
 					step.AddScore(score.GetAnnouncementsDetail)
@@ -472,7 +472,7 @@ func (s *Scenario) readAnnouncementPagingScenario(student *model.Student, step *
 				return
 			}
 
-			expectAnnounceList := student.AnnouncementsMap()
+			expectAnnouncementMap := student.AnnouncementsMap()
 
 			startGetAnnouncementList := time.Now()
 			// 学生はお知らせを確認し続ける
@@ -485,7 +485,7 @@ func (s *Scenario) readAnnouncementPagingScenario(student *model.Student, step *
 			s.debugData.AddInt("GetAnnouncementListTime", time.Since(startGetAnnouncementList).Milliseconds())
 
 			// 並列で走る既読にするシナリオが未読/既読状態を変更するので、こちらのシナリオでは未読/既読状態は検証しない
-			if err := verifyAnnouncementsList(&res, expectAnnounceList, false); err != nil {
+			if err := verifyAnnouncementsList(expectAnnouncementMap, &res, false); err != nil {
 				step.AddError(err)
 			} else {
 				step.AddScore(score.ScoreGetAnnouncementList)
@@ -522,7 +522,7 @@ func (s *Scenario) readAnnouncementPagingScenario(student *model.Student, step *
 					continue
 				}
 
-				if err := verifyAnnouncementDetail(&res, expectStatus); err != nil {
+				if err := verifyAnnouncementDetail(expectStatus, &res); err != nil {
 					step.AddError(err)
 				} else {
 					step.AddScore(score.GetAnnouncementsDetail)
@@ -817,7 +817,7 @@ func (s *Scenario) addActiveStudentLoads(ctx context.Context, step *isucandar.Be
 				step.AddError(err)
 				return
 			}
-			if err := verifyMe(&res, student.UserAccount, false); err != nil {
+			if err := verifyMe(student.UserAccount, &res); err != nil {
 				step.AddError(err)
 				return
 			}
@@ -861,7 +861,7 @@ func (s *Scenario) addCourseLoad(ctx context.Context, dayOfWeek, period int, ste
 		step.AddError(err)
 		return
 	}
-	if err := verifyMe(&getMeRes, teacher.UserAccount, true); err != nil {
+	if err := verifyMe(teacher.UserAccount, &getMeRes); err != nil {
 		step.AddError(err)
 		return
 	}
@@ -937,7 +937,7 @@ func (s *Scenario) submitAssignments(ctx context.Context, students map[string]*m
 				step.AddError(err)
 				return
 			}
-			if err := verifyClasses(res, course.Classes()); err != nil {
+			if err := verifyClasses(course.Classes(), res); err != nil {
 				step.AddError(err)
 			} else {
 				step.AddScore(score.CourseGetClasses)

--- a/benchmarker/scenario/prepare.go
+++ b/benchmarker/scenario/prepare.go
@@ -140,7 +140,7 @@ func (s *Scenario) prepareNormal(ctx context.Context, step *isucandar.BenchmarkS
 			step.AddError(err)
 			return
 		}
-		if err := verifyMe(&getMeRes, teacher.UserAccount, true); err != nil {
+		if err := verifyMe(teacher.UserAccount, &getMeRes); err != nil {
 			step.AddError(err)
 			return
 		}
@@ -184,7 +184,7 @@ func (s *Scenario) prepareNormal(ctx context.Context, step *isucandar.BenchmarkS
 			step.AddError(err)
 			return
 		}
-		if err := verifyMe(&getMeRes, student.UserAccount, false); err != nil {
+		if err := verifyMe(student.UserAccount, &getMeRes); err != nil {
 			step.AddError(err)
 			return
 		}
@@ -1076,6 +1076,7 @@ func (s *Scenario) prepareCheckLoginAbnormal(ctx context.Context) error {
 		Code:        "X12345",
 		Name:        "unknown",
 		RawPassword: "password",
+		IsAdmin:     false,
 	})
 	if err == nil {
 		return errInvalidLogin
@@ -1089,6 +1090,7 @@ func (s *Scenario) prepareCheckLoginAbnormal(ctx context.Context) error {
 		Code:        student.Code,
 		Name:        student.Name,
 		RawPassword: student.RawPassword + "abc",
+		IsAdmin:     false,
 	})
 	if err == nil {
 		return errInvalidLogin

--- a/benchmarker/scenario/userpool.go
+++ b/benchmarker/scenario/userpool.go
@@ -42,6 +42,7 @@ func NewUserPool(studentAccounts []*model.UserAccount, teacherAccounts []*model.
 		Code:        sampleTeacherID,
 		Name:        sampleTeacherName,
 		RawPassword: sampleTeacherPass,
+		IsAdmin:     true,
 	}, baseURL)
 
 	teachers := make([]*model.Teacher, len(teacherAccounts))
@@ -69,6 +70,7 @@ func (p *userPool) newStudent() (*model.Student, error) {
 			Code:        sampleStudentID,
 			Name:        sampleStudentName,
 			RawPassword: sampleStudentPass,
+			IsAdmin:     false,
 		}, p.baseURL), nil
 	}
 

--- a/benchmarker/scenario/validation.go
+++ b/benchmarker/scenario/validation.go
@@ -3,7 +3,6 @@ package scenario
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/rand"
 	"sync"
 	"time"
@@ -284,8 +283,7 @@ func (s *Scenario) validateGrades(ctx context.Context, step *isucandar.Benchmark
 }
 
 func validateUserGrade(expected *model.GradeRes, actual *api.GetGradeResponse) error {
-	if len(expected.CourseResults) != len(actual.CourseResults) {
-		AdminLogger.Println("courseResult len. expected: ", len(expected.CourseResults), "actual: ", len(actual.CourseResults))
+	if !AssertEqual("grade courses length", len(expected.CourseResults), len(actual.CourseResults)) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認の courses の数が一致しません"))
 	}
 
@@ -311,33 +309,27 @@ func validateUserGrade(expected *model.GradeRes, actual *api.GetGradeResponse) e
 }
 
 func validateSummary(expected *model.Summary, actual *api.Summary) error {
-	if expected.Credits != actual.Credits {
-		AdminLogger.Println("credits. expected: ", expected.Credits, "actual: ", actual.Credits)
+	if !AssertEqual("grade summary credits", expected.Credits, actual.Credits) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のsummaryのcreditsが一致しません"))
 	}
 
-	if math.Abs(expected.GPA-actual.GPA) > validateGPAErrorTolerance {
-		AdminLogger.Println("gpa. expected: ", expected.GPA, "actual: ", actual.GPA)
+	if !AssertWithinTolerance("grade summary gpa", expected.GPA, actual.GPA, validateGPAErrorTolerance) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のsummaryのgpaが一致しません"))
 	}
 
-	if math.Abs(expected.GpaAvg-actual.GpaAvg) > validateGPAErrorTolerance {
-		AdminLogger.Println("gpaavg. expected: ", expected.GpaAvg, "actual: ", actual.GpaAvg)
+	if !AssertWithinTolerance("grade summary gpa_avg", expected.GpaAvg, actual.GpaAvg, validateGPAErrorTolerance) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のsummaryのgpa_avgが一致しません"))
 	}
 
-	if math.Abs(expected.GpaMax-actual.GpaMax) > validateGPAErrorTolerance {
-		AdminLogger.Println("gpamax. expected: ", expected.GpaMax, "actual: ", actual.GpaMax)
+	if !AssertWithinTolerance("grade summary gpa_max", expected.GpaMax, actual.GpaMax, validateGPAErrorTolerance) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のsummaryのgpa_maxが一致しません"))
 	}
 
-	if math.Abs(expected.GpaMin-actual.GpaMin) > validateGPAErrorTolerance {
-		AdminLogger.Println("gpamin. expected: ", expected.GpaMin, "actual: ", actual.GpaMin)
+	if !AssertWithinTolerance("grade summary gpa_min", expected.GpaMin, actual.GpaMin, validateGPAErrorTolerance) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のsummaryのgpa_minが一致しません"))
 	}
 
-	if math.Abs(expected.GpaTScore-actual.GpaTScore) > validateGPAErrorTolerance {
-		AdminLogger.Println("gpatscore. expected: ", expected.GpaTScore, "actual: ", actual.GpaTScore)
+	if !AssertWithinTolerance("grade summary gpa_t_score", expected.GpaTScore, actual.GpaTScore, validateGPAErrorTolerance) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のsummaryのgpa_t_scoreが一致しません"))
 	}
 
@@ -345,43 +337,35 @@ func validateSummary(expected *model.Summary, actual *api.Summary) error {
 }
 
 func validateCourseResult(expected *model.CourseResult, actual *api.CourseResult) error {
-	if expected.Name != actual.Name {
-		AdminLogger.Println("name. expected: ", expected.Name, "actual: ", actual.Name)
+	if !AssertEqual("grade courses name", expected.Name, actual.Name) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースの名前が一致しません"))
 	}
 
-	if expected.Code != actual.Code {
-		AdminLogger.Println("code. expected: ", expected.Code, "actual: ", actual.Code)
+	if !AssertEqual("grade courses code", expected.Code, actual.Code) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのコードが一致しません"))
 	}
 
-	if expected.TotalScore != actual.TotalScore {
-		AdminLogger.Println("TotalScore. expected: ", expected.TotalScore, "actual: ", actual.TotalScore)
+	if !AssertEqual("grade courses total_score", expected.TotalScore, actual.TotalScore) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreが一致しません"))
 	}
 
-	if expected.TotalScoreMax != actual.TotalScoreMax {
-		AdminLogger.Println("TotalScoreMax. expected: ", expected.TotalScoreMax, "actual: ", actual.TotalScoreMax)
+	if !AssertEqual("grade courses total_score_max", expected.TotalScoreMax, actual.TotalScoreMax) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreMaxが一致しません"))
 	}
 
-	if expected.TotalScoreMin != actual.TotalScoreMin {
-		AdminLogger.Println("TotalScoreMin. expected: ", expected.TotalScoreMin, "actual: ", actual.TotalScoreMin)
+	if !AssertEqual("grade courses total_score_min", expected.TotalScoreMin, actual.TotalScoreMin) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreMinが一致しません"))
 	}
 
-	if math.Abs(expected.TotalScoreAvg-actual.TotalScoreAvg) > validateTotalScoreErrorTolerance {
-		AdminLogger.Println("TotalScoreAvg. expected: ", expected.TotalScoreAvg, "actual: ", actual.TotalScoreAvg)
+	if !AssertWithinTolerance("grade courses total_score_avg", expected.TotalScoreAvg, actual.TotalScoreAvg, validateTotalScoreErrorTolerance) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreAvgが一致しません"))
 	}
 
-	if math.Abs(expected.TotalScoreTScore-actual.TotalScoreTScore) > validateTotalScoreErrorTolerance {
-		AdminLogger.Println("TotalScoreTScore. expected: ", expected.TotalScoreTScore, "actual: ", actual.TotalScoreTScore)
+	if !AssertWithinTolerance("grade courses total_score_t_score", expected.TotalScoreTScore, actual.TotalScoreTScore, validateTotalScoreErrorTolerance) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreTScoreが一致しません"))
 	}
 
-	if len(expected.ClassScores) != len(actual.ClassScores) {
-		AdminLogger.Println("len ClassScores. expected: ", len(expected.ClassScores), "actual: ", len(actual.ClassScores))
+	if !AssertEqual("grade courses class_scores length", len(expected.ClassScores), len(actual.ClassScores)) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のClassScoresの数が一致しません"))
 	}
 
@@ -397,29 +381,23 @@ func validateCourseResult(expected *model.CourseResult, actual *api.CourseResult
 }
 
 func validateClassScore(expected *model.ClassScore, actual *api.ClassScore) error {
-	if expected.ClassID != actual.ClassID {
-		AdminLogger.Println("classID. expected: ", expected.ClassID, "actual: ", actual.ClassID)
+	if !AssertEqual("grade courses class_scores class_id", expected.ClassID, actual.ClassID) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスのIDが一致しません"))
 	}
 
-	if expected.Part != actual.Part {
-		AdminLogger.Println("part. expected: ", expected.Part, "actual: ", actual.Part)
+	if !AssertEqual("grade courses class_scores part", expected.Part, actual.Part) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスのpartが一致しません"))
 	}
 
-	if expected.Title != actual.Title {
-		AdminLogger.Println("title. expected: ", expected.Title, "actual: ", actual.Title)
+	if !AssertEqual("grade courses class_scores title", expected.Title, actual.Title) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスのタイトルが一致しません"))
 	}
 
-	if !((expected.Score == nil && actual.Score == nil) ||
-		((expected.Score != nil && actual.Score != nil) && (*expected.Score == *actual.Score))) {
-		AdminLogger.Println("score. expected: ", expected.Score, "actual: ", actual.Score)
+	if !AssertEqual("grade courses class_scores score", expected.Score, actual.Score) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスのスコアが一致しません"))
 	}
 
-	if expected.SubmitterCount != actual.Submitters {
-		AdminLogger.Println("submitters. expected: ", expected.SubmitterCount, "actual: ", actual.Submitters)
+	if !AssertEqual("grade courses class_scores submitters", expected.SubmitterCount, actual.Submitters) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスの課題提出者の数が一致しません"))
 	}
 

--- a/benchmarker/scenario/verify.go
+++ b/benchmarker/scenario/verify.go
@@ -56,19 +56,20 @@ func verifyInitialize(res api.InitializeResponse) error {
 	if res.Language == "" {
 		return errInvalidResponse("initialize のレスポンスに利用言語が設定されていません")
 	}
+
 	return nil
 }
 
-func verifyMe(res *api.GetMeResponse, expectedUserAccount *model.UserAccount, expectedAdminFlag bool) error {
-	if res.Code != expectedUserAccount.Code {
+func verifyMe(expected *model.UserAccount, res *api.GetMeResponse) error {
+	if !AssertEqual("account code", expected.Code, res.Code) {
 		return errInvalidResponse("学籍番号が期待する値と一致しません")
 	}
 
-	if res.Name != expectedUserAccount.Name {
+	if !AssertEqual("account name", expected.Name, res.Name) {
 		return errInvalidResponse("氏名が期待する値と一致しません")
 	}
 
-	if res.IsAdmin != expectedAdminFlag {
+	if !AssertEqual("account is_admin", expected.IsAdmin, res.IsAdmin) {
 		return errInvalidResponse("管理者フラグが期待する値と一致しません")
 	}
 
@@ -95,7 +96,7 @@ func collectVerifyGradesData(student *model.Student) map[string]interface{} {
 
 func verifyGrades(expected map[string]interface{}, res *api.GetGradeResponse) error {
 	// summaryはcreditが検証できそうな気がするけどめんどくさいのでしてない
-	if len(expected) != len(res.CourseResults) {
+	if !AssertEqual("grade courses length", len(expected), len(res.CourseResults)) {
 		return errInvalidResponse("成績確認でのコース結果の数が一致しません")
 	}
 
@@ -118,27 +119,23 @@ func verifyGrades(expected map[string]interface{}, res *api.GetGradeResponse) er
 		default:
 			panic(fmt.Sprintf("expect %T or %T, actual %T", &model.SimpleCourseResult{}, &model.CourseResult{}, v))
 		}
-
 	}
 
 	return nil
 }
 
 func verifySimpleCourseResult(expected *model.SimpleCourseResult, res *api.CourseResult) error {
-	if expected.Name != res.Name {
-		AdminLogger.Println(fmt.Printf("expected: %s, actual: %s", expected.Name, res.Name))
+	if !AssertEqual("grade courses name", expected.Name, res.Name) {
 		return errInvalidResponse("成績確認結果のコース名が違います")
 	}
 
-	if expected.Code != res.Code {
-		AdminLogger.Println(fmt.Printf("expected: %s, actual: %s", expected.Code, res.Code))
-		return errInvalidResponse("成績確認の生徒のCodeが一致しません")
+	if !AssertEqual("grade courses code", expected.Code, res.Code) {
+		return errInvalidResponse("成績確認の科目コードが一致しません")
 	}
 
 	// リクエスト前の時点で登録成功しているクラスの成績は、成績レスポンスに必ず含まれている
 	// そのため、追加済みクラスのスコアの数よりレスポンス内クラスのスコアの数が少ない場合はエラーとなる
-	if len(expected.SimpleClassScores) > len(res.ClassScores) {
-		AdminLogger.Println(fmt.Printf("expected: %d, actual: %d", len(expected.SimpleClassScores), len(res.ClassScores)))
+	if !AssertGreaterOrEqual("grade courses class_scores length", len(expected.SimpleClassScores), len(res.ClassScores)) {
 		return errInvalidResponse("成績確認のクラスのスコアの数が正しくありません")
 	}
 
@@ -158,39 +155,35 @@ func verifySimpleCourseResult(expected *model.SimpleCourseResult, res *api.Cours
 }
 
 func verifyClassScores(expected *model.SimpleClassScore, res *api.ClassScore) error {
-	if expected.ClassID != res.ClassID {
-		AdminLogger.Println("expected: ", expected.ClassID, "actual: ", res.ClassID)
+	if !AssertEqual("grade courses class_scores class_id", expected.ClassID, res.ClassID) {
 		return errInvalidResponse("成績確認でのクラスのIDが一致しません")
 	}
-	if expected.Part != res.Part {
-		AdminLogger.Println("expected: ", expected.Part, "actual: ", res.Part)
+
+	if !AssertEqual("grade courses class_scores part", expected.Part, res.Part) {
 		return errInvalidResponse("成績確認でのクラスのpartが一致しません")
 	}
 
-	if expected.Title != res.Title {
-		AdminLogger.Println("expected: ", expected.Title, "actual: ", res.Title)
+	if !AssertEqual("grade courses class_scores title", expected.Title, res.Title) {
 		return errInvalidResponse("成績確認でのクラスのタイトルが一致しません")
 	}
 
-	if !((expected.Score == nil && res.Score == nil) ||
-		((expected.Score != nil && res.Score != nil) && (*expected.Score == *res.Score))) {
-		AdminLogger.Println("expected: ", expected.Score, "actual: ", res.Score)
+	if !AssertEqual("grade courses class_scores score", expected.Score, res.Score) {
 		return errInvalidResponse("成績確認でのクラスのスコアが一致しません")
 	}
 
 	return nil
 }
 
-func verifyRegisteredCourse(actual *api.GetRegisteredCourseResponseContent, expected *model.Course) error {
-	if actual.ID != expected.ID {
+func verifyRegisteredCourse(expected *model.Course, actual *api.GetRegisteredCourseResponseContent) error {
+	if !AssertEqual("registered_course id", expected.ID, actual.ID) {
 		return errInvalidResponse("コースのIDが期待する値と一致しません")
 	}
 
-	if actual.Name != expected.Name {
+	if !AssertEqual("registered_course name", expected.Name, actual.Name) {
 		return errInvalidResponse("コース名が期待する値と一致しません")
 	}
 
-	if actual.Teacher != expected.Teacher().Name {
+	if !AssertEqual("registered_course teacher", expected.Teacher().Name, actual.Teacher) {
 		return errInvalidResponse("コースの講師が期待する値と一致しません")
 	}
 
@@ -199,7 +192,7 @@ func verifyRegisteredCourse(actual *api.GetRegisteredCourseResponseContent, expe
 	return nil
 }
 
-func verifyRegisteredCourses(res []*api.GetRegisteredCourseResponseContent, expectedSchedule [5][6]*model.Course) error {
+func verifyRegisteredCourses(expectedSchedule [5][6]*model.Course, res []*api.GetRegisteredCourseResponseContent) error {
 	// DayOfWeekの逆引きテーブル（string -> int）
 	dayOfWeekIndexTable := map[api.DayOfWeek]int{
 		"monday":    0,
@@ -226,14 +219,14 @@ func verifyRegisteredCourses(res []*api.GetRegisteredCourseResponseContent, expe
 		actualSchedule[dayOfWeekIndex][periodIndex] = resContent
 	}
 
-	// 科目の終了処理は履修済み科目取得のリクエストと並列で走るため、ベンチに存在する科目(registeredSchedule)がレスポンスに存在しないことは許容する。
-	// ただし、registeredScheduleは履修済み科目取得のリクエスト直前に取得してそれ以降削除されず、また履修登録は直列であるため、レスポンスに存在する科目は必ずベンチにも存在することを期待する。
-	// したがって、レスポンスに含まれる科目はベンチにある科目(registeredSchedule)の部分集合であることを確認すれば十分である。
+	// 科目の終了処理は履修済み科目取得のリクエストと並列で走るため、ベンチに存在する科目(expectedSchedule)がレスポンスに存在しないことは許容する。
+	// ただし、expectedScheduleは履修済み科目取得のリクエスト直前に取得してそれ以降削除されず、また履修登録は直列であるため、レスポンスに存在する科目は必ずベンチにも存在することを期待する。
+	// したがって、レスポンスに含まれる科目はベンチにある科目(expectedSchedule)の部分集合であることを確認すれば十分である。
 	for d := 0; d < 5; d++ {
 		for p := 0; p < 6; p++ {
 			if actualSchedule[d][p] != nil {
 				if expectedSchedule[d][p] != nil {
-					if err := verifyRegisteredCourse(actualSchedule[d][p], expectedSchedule[d][p]); err != nil {
+					if err := verifyRegisteredCourse(expectedSchedule[d][p], actualSchedule[d][p]); err != nil {
 						return err
 					}
 				} else {
@@ -295,6 +288,14 @@ func verifySearchCourseResult(res *api.GetCourseDetailResponse, param *model.Sea
 }
 
 func verifySearchCourseResults(res []*api.GetCourseDetailResponse, param *model.SearchCourseParam) error {
+	// Code の昇順でソートされているか
+	for i := 0; i < len(res)-1; i++ {
+		if res[i].Code > res[i+1].Code {
+			return errInvalidResponse("科目検索結果の順序が不正です")
+		}
+	}
+
+	// 取得されたものが検索条件にマッチするか
 	for _, course := range res {
 		if rand.Float64() < searchCourseVerifyRate {
 			if err := verifySearchCourseResult(course, param); err != nil {
@@ -303,81 +304,78 @@ func verifySearchCourseResults(res []*api.GetCourseDetailResponse, param *model.
 		}
 	}
 
-	// Code の昇順でソートされているか
-	for i := 0; i < len(res)-1; i++ {
-		if res[i].Code > res[i+1].Code {
-			return errInvalidResponse("科目検索結果の順序が不正です")
-		}
-	}
-
 	return nil
 }
 
-func verifyCourseDetail(actual *api.GetCourseDetailResponse, expected *model.Course) error {
-	if actual.Code != expected.Code {
+func verifyCourseDetail(expected *model.Course, actual *api.GetCourseDetailResponse) error {
+	if !AssertEqual("course id", expected.Code, actual.Code) {
+		return errInvalidResponse("科目IDが期待する値と一致しません")
+	}
+
+	if !AssertEqual("course code", expected.Code, actual.Code) {
 		return errInvalidResponse("科目のコードが期待する値と一致しません")
 	}
 
-	if actual.Type != api.CourseType(expected.Type) {
+	if !AssertEqual("course type", api.CourseType(expected.Type), actual.Type) {
 		return errInvalidResponse("科目のタイプが期待する値と一致しません")
 	}
 
-	if actual.Name != expected.Name {
+	if !AssertEqual("course name", expected.Name, actual.Name) {
 		return errInvalidResponse("科目名が期待する値と一致しません")
 	}
 
-	if actual.Description != expected.Description {
+	if !AssertEqual("course description", expected.Description, actual.Description) {
 		return errInvalidResponse("科目の詳細が期待する値と一致しません")
 	}
 
-	if actual.Credit != uint8(expected.Credit) {
+	if !AssertEqual("course credit", uint8(expected.Credit), actual.Credit) {
 		return errInvalidResponse("科目の単位数が期待する値と一致しません")
 	}
 
-	if actual.Period != uint8(expected.Period+1) {
+	if !AssertEqual("course period", uint8(expected.Period+1), actual.Period) {
 		return errInvalidResponse("科目の開講時限が期待する値と一致しません")
 	}
 
-	if actual.DayOfWeek != api.DayOfWeekTable[expected.DayOfWeek] {
+	if !AssertEqual("course day_of_week", api.DayOfWeekTable[expected.DayOfWeek], actual.DayOfWeek) {
 		return errInvalidResponse("科目の開講曜日が期待する値と一致しません")
 	}
 
-	if actual.Teacher != expected.Teacher().Name {
+	if !AssertEqual("course teacher", expected.Teacher().Name, actual.Teacher) {
 		return errInvalidResponse("科目の講師が期待する値と一致しません")
 	}
 
-	if actual.Keywords != expected.Keywords {
+	if !AssertEqual("course keywords", expected.Keywords, actual.Keywords) {
 		return errInvalidResponse("科目のキーワードが期待する値と一致しません")
 	}
 
 	return nil
 }
 
-func verifyAnnouncementDetail(res *api.GetAnnouncementDetailResponse, announcementStatus *model.AnnouncementStatus) error {
-	if res.ID != announcementStatus.Announcement.ID {
+func verifyAnnouncementDetail(expected *model.AnnouncementStatus, res *api.GetAnnouncementDetailResponse) error {
+	if !AssertEqual("announcement_detail id", expected.Announcement.ID, res.ID) {
 		return errInvalidResponse("お知らせのIDが期待する値と一致しません")
 	}
 
-	if res.CourseID != announcementStatus.Announcement.CourseID {
+	if !AssertEqual("announcement_detail course_id", expected.Announcement.CourseID, res.CourseID) {
 		return errInvalidResponse("お知らせの講義IDが期待する値と一致しません")
 	}
 
-	if res.CourseName != announcementStatus.Announcement.CourseName {
+	if !AssertEqual("announcement_detail course_name", expected.Announcement.CourseName, res.CourseName) {
 		return errInvalidResponse("お知らせの講義名が期待する値と一致しません")
 	}
 
-	if res.Title != announcementStatus.Announcement.Title {
+	if !AssertEqual("announcement_detail title", expected.Announcement.Title, res.Title) {
 		return errInvalidResponse("お知らせのタイトルが期待する値と一致しません")
 	}
 
-	if res.Message != announcementStatus.Announcement.Message {
+	if !AssertEqual("announcement_detail message", expected.Announcement.Message, res.Message) {
 		return errInvalidResponse("お知らせのメッセージが期待する値と一致しません")
 	}
 
 	// Dirtyフラグが立っていない場合のみ、Unreadの検証を行う
 	// 既読化RequestがTimeoutで中断された際、ベンチには既読が反映しないがwebapp側が既読化される可能性があるため。
-	if !announcementStatus.Dirty {
-		if !AssertEqual("announce unread", announcementStatus.Unread, res.Unread) {
+	if !expected.Dirty {
+		if !AssertEqual("announcement_detail unread", expected.Unread, res.Unread) {
 			return errInvalidResponse("お知らせの未読/既読状態が期待する値と一致しません")
 		}
 	}
@@ -386,35 +384,7 @@ func verifyAnnouncementDetail(res *api.GetAnnouncementDetailResponse, announceme
 }
 
 // お知らせ一覧の中身の検証
-func verifyAnnouncementsList(res *api.GetAnnouncementsResponse, expectList map[string]*model.AnnouncementStatus, verifyUnread bool) error {
-	// リストの中身の検証
-	for _, actual := range res.Announcements {
-		expectStatus, ok := expectList[actual.ID]
-		if !ok {
-			// webappでは認識されているが、ベンチではまだ認識されていないお知らせ（お知らせ登録がリトライ中の場合発生）
-			// load中には検証できないのでskip
-			continue
-		}
-
-		if !AssertEqual("announcement list course id", expectStatus.Announcement.CourseID, actual.CourseID) {
-			return errInvalidResponse("お知らせの科目IDが期待する値と一致しません")
-		}
-		if !AssertEqual("announcement list course name", expectStatus.Announcement.CourseName, actual.CourseName) {
-			return errInvalidResponse("お知らせの科目名が期待する値と一致しません")
-		}
-		if !AssertEqual("announcement list title", expectStatus.Announcement.Title, actual.Title) {
-			return errInvalidResponse("お知らせのタイトルが期待する値と一致しません")
-		}
-
-		// Dirtyフラグが立っていない場合のみ、Unreadの検証を行う
-		// 既読化RequestがTimeoutで中断された際、ベンチには既読が反映しないがwebapp側が既読化される可能性があるため。
-		if verifyUnread && !expectStatus.Dirty {
-			if !AssertEqual("announce unread", expectStatus.Unread, actual.Unread) {
-				return errInvalidResponse("お知らせの未読/既読状態が期待する値と一致しません")
-			}
-		}
-	}
-
+func verifyAnnouncementsList(expectedMap map[string]*model.AnnouncementStatus, res *api.GetAnnouncementsResponse, verifyUnread bool) error {
 	// id の降順でソートされているか
 	for i := 0; i < len(res.Announcements)-1; i++ {
 		if res.Announcements[i].ID < res.Announcements[i+1].ID {
@@ -422,26 +392,54 @@ func verifyAnnouncementsList(res *api.GetAnnouncementsResponse, expectList map[s
 		}
 	}
 
-	// MEMO: res.UnreadCountはload中には検証できない
+	// リストの中身の検証
+	for _, actual := range res.Announcements {
+		expectStatus, ok := expectedMap[actual.ID]
+		if !ok {
+			// webappでは認識されているが、ベンチではまだ認識されていないお知らせ（お知らせ登録がリトライ中の場合発生）
+			// load中には検証できないのでskip
+			continue
+		}
+
+		if !AssertEqual("announcement_list announcements course_id", expectStatus.Announcement.CourseID, actual.CourseID) {
+			return errInvalidResponse("お知らせの科目IDが期待する値と一致しません")
+		}
+		if !AssertEqual("announcement_list announcements course_name", expectStatus.Announcement.CourseName, actual.CourseName) {
+			return errInvalidResponse("お知らせの科目名が期待する値と一致しません")
+		}
+		if !AssertEqual("announcement_list announcements title", expectStatus.Announcement.Title, actual.Title) {
+			return errInvalidResponse("お知らせのタイトルが期待する値と一致しません")
+		}
+
+		// Dirtyフラグが立っていない場合のみ、Unreadの検証を行う
+		// 既読化RequestがTimeoutで中断された際、ベンチには既読が反映しないがwebapp側が既読化される可能性があるため。
+		if verifyUnread && !expectStatus.Dirty {
+			if !AssertEqual("announcement_list announcements unread", expectStatus.Unread, actual.Unread) {
+				return errInvalidResponse("お知らせの未読/既読状態が期待する値と一致しません")
+			}
+		}
+	}
+
+	// unread_count はload中には検証できない
 
 	return nil
 }
 
-func verifyClass(res *api.GetClassResponse, class *model.Class) error {
-	if res.ID != class.ID {
+func verifyClass(expected *model.Class, actual *api.GetClassResponse) error {
+	if !AssertEqual("class id", expected.ID, actual.ID) {
 		return errInvalidResponse("講義IDが期待する値と一致しません")
 	}
 
-	if res.Title != class.Title {
+	if !AssertEqual("class part", expected.Part, actual.Part) {
+		return errInvalidResponse("講義のパートが期待する値と一致しません")
+	}
+
+	if !AssertEqual("class title", expected.Title, actual.Title) {
 		return errInvalidResponse("講義のタイトルが期待する値と一致しません")
 	}
 
-	if res.Description != class.Desc {
+	if !AssertEqual("class description", expected.Desc, actual.Description) {
 		return errInvalidResponse("講義の説明文が期待する値と一致しません")
-	}
-
-	if res.Part != class.Part {
-		return errInvalidResponse("講義のパートが期待する値と一致しません")
 	}
 
 	// TODO: SubmissionClosedAtの検証
@@ -450,14 +448,14 @@ func verifyClass(res *api.GetClassResponse, class *model.Class) error {
 	return nil
 }
 
-func verifyClasses(res []*api.GetClassResponse, classes []*model.Class) error {
-	if len(res) != len(classes) {
+func verifyClasses(expected []*model.Class, res []*api.GetClassResponse) error {
+	if !AssertEqual("class_list length", len(expected), len(res)) {
 		return errInvalidResponse("講義数が期待する数と一致しません")
 	}
 
 	if len(res) > 0 {
 		// 最後に追加された講義だけ中身を検証する
-		return verifyClass(res[len(res)-1], classes[len(classes)-1])
+		return verifyClass(expected[len(expected)-1], res[len(res)-1])
 	}
 
 	return nil
@@ -484,18 +482,20 @@ func verifyAssignments(assignmentsData []byte, class *model.Class) error {
 			downloadedAssignments[f.Name] = crc32.ChecksumIEEE(assignmentData)
 		}
 
+		expectedSubmissions := class.Submissions()
+
 		// mapのサイズが等しく、提出した課題がすべてダウンロードされた課題に含まれていれば、提出した課題とダウンロードされた課題は集合として等しい
-		if len(downloadedAssignments) != class.GetSubmittedCount() {
+		if !AssertEqual("assignment length", len(expectedSubmissions), len(downloadedAssignments)) {
 			return errInvalidResponse("課題zipに含まれるファイルの数が期待する値と一致しません")
 		}
 
-		for studentCode, submission := range class.Submissions() {
-			expectedFileName := studentCode + "-" + submission.Title
-			checksumDownloaded, ok := downloadedAssignments[expectedFileName]
+		for studentCode, expectedSubmission := range expectedSubmissions {
+			expectedFileName := studentCode + "-" + expectedSubmission.Title
+			actualChecksum, ok := downloadedAssignments[expectedFileName]
 			if !ok {
 				return errInvalidResponse("提出した課題が課題zipに含まれていないか、ファイル名が間違っています")
 			}
-			if submission.Checksum != checksumDownloaded {
+			if !AssertEqual("assignment checksum", expectedSubmission.Checksum, actualChecksum) {
 				return errInvalidResponse("提出した課題とダウンロードされた課題の内容が一致しません")
 			}
 		}
@@ -572,7 +572,7 @@ func verifyChecksum(res *http.Response, expectPath string) error {
 	io.Copy(hash, res.Body)
 	actual := fmt.Sprintf("%x", hash.Sum(nil))
 
-	if expected != actual {
+	if !AssertEqual("resource checksum", expected, actual) {
 		return failure.NewError(fails.ErrStaticResource, fmt.Errorf("期待するチェックサムと一致しません(%s)", expectPath))
 	}
 	return nil


### PR DESCRIPTION
- verify/validationの比較時に `AssertEqual` を使うように（検証失敗時にAdminLoggerに出す）
- 引数の順番を一部変更（基本的にexpected, actualの順に）