### PR TITLE
load中のレスポンス誤りをcriticalにしない

### DIFF
--- a/benchmarker/scenario/assert.go
+++ b/benchmarker/scenario/assert.go
@@ -3,6 +3,9 @@ package scenario
 import (
 	"math"
 	"reflect"
+
+	"github.com/isucon/isucon11-final/benchmarker/api"
+	"github.com/isucon/isucon11-final/benchmarker/model"
 )
 
 func AssertEqual(msg string, expected interface{}, actual interface{}) bool {
@@ -44,4 +47,72 @@ func AssertWithinTolerance(msg string, expect, actual, tolerance float64) bool {
 		AdminLogger.Printf("%s: expected: %f ± %.2f / actual: %f", msg, expect, tolerance, actual)
 	}
 	return r
+}
+
+func assertEqualCourseResult(expected *model.CourseResult, actual *api.CourseResult) error {
+	if !AssertEqual("grade courses name", expected.Name, actual.Name) {
+		return errInvalidResponse("成績確認のコースの名前が一致しません")
+	}
+
+	if !AssertEqual("grade courses code", expected.Code, actual.Code) {
+		return errInvalidResponse("成績確認のコースのコードが一致しません")
+	}
+
+	if !AssertEqual("grade courses total_score", expected.TotalScore, actual.TotalScore) {
+		return errInvalidResponse("成績確認のコースのTotalScoreが一致しません")
+	}
+
+	if !AssertEqual("grade courses total_score_max", expected.TotalScoreMax, actual.TotalScoreMax) {
+		return errInvalidResponse("成績確認のコースのTotalScoreMaxが一致しません")
+	}
+
+	if !AssertEqual("grade courses total_score_min", expected.TotalScoreMin, actual.TotalScoreMin) {
+		return errInvalidResponse("成績確認のコースのTotalScoreMinが一致しません")
+	}
+
+	if !AssertWithinTolerance("grade courses total_score_avg", expected.TotalScoreAvg, actual.TotalScoreAvg, validateTotalScoreErrorTolerance) {
+		return errInvalidResponse("成績確認のコースのTotalScoreAvgが一致しません")
+	}
+
+	if !AssertWithinTolerance("grade courses total_score_t_score", expected.TotalScoreTScore, actual.TotalScoreTScore, validateTotalScoreErrorTolerance) {
+		return errInvalidResponse("成績確認のコースのTotalScoreTScoreが一致しません")
+	}
+
+	if !AssertEqual("grade courses class_scores length", len(expected.ClassScores), len(actual.ClassScores)) {
+		return errInvalidResponse("成績確認のClassScoresの数が一致しません")
+	}
+
+	for i := 0; i < len(expected.ClassScores); i++ {
+		// webapp 側は新しい(partが大きい)classから順番に帰ってくるので古いクラスから見るようにしている
+		err := assertEqualClassScore(expected.ClassScores[i], &actual.ClassScores[len(actual.ClassScores)-i-1])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func assertEqualClassScore(expected *model.ClassScore, actual *api.ClassScore) error {
+	if !AssertEqual("grade courses class_scores class_id", expected.ClassID, actual.ClassID) {
+		return errInvalidResponse("成績確認のクラスのIDが一致しません")
+	}
+
+	if !AssertEqual("grade courses class_scores part", expected.Part, actual.Part) {
+		return errInvalidResponse("成績確認のクラスのpartが一致しません")
+	}
+
+	if !AssertEqual("grade courses class_scores title", expected.Title, actual.Title) {
+		return errInvalidResponse("成績確認のクラスのタイトルが一致しません")
+	}
+
+	if !AssertEqual("grade courses class_scores score", expected.Score, actual.Score) {
+		return errInvalidResponse("成績確認のクラスのスコアが一致しません")
+	}
+
+	if !AssertEqual("grade courses class_scores submitters", expected.SubmitterCount, actual.Submitters) {
+		return errInvalidResponse("成績確認のクラスの課題提出者の数が一致しません")
+	}
+
+	return nil
 }

--- a/benchmarker/scenario/validation.go
+++ b/benchmarker/scenario/validation.go
@@ -297,9 +297,9 @@ func validateUserGrade(expected *model.GradeRes, actual *api.GetGradeResponse) e
 		}
 
 		expected := expected.CourseResults[courseResult.Code]
-		err := validateCourseResult(expected, &courseResult)
+		err := assertEqualCourseResult(expected, &courseResult)
 		if err != nil {
-			return err
+			return failure.NewError(fails.ErrCritical, err)
 		}
 	}
 
@@ -329,74 +329,6 @@ func validateSummary(expected *model.Summary, actual *api.Summary) error {
 
 	if !AssertWithinTolerance("grade summary gpa_t_score", expected.GpaTScore, actual.GpaTScore, validateGPAErrorTolerance) {
 		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のsummaryのgpa_t_scoreが一致しません"))
-	}
-
-	return nil
-}
-
-func validateCourseResult(expected *model.CourseResult, actual *api.CourseResult) error {
-	if !AssertEqual("grade courses name", expected.Name, actual.Name) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースの名前が一致しません"))
-	}
-
-	if !AssertEqual("grade courses code", expected.Code, actual.Code) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのコードが一致しません"))
-	}
-
-	if !AssertEqual("grade courses total_score", expected.TotalScore, actual.TotalScore) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreが一致しません"))
-	}
-
-	if !AssertEqual("grade courses total_score_max", expected.TotalScoreMax, actual.TotalScoreMax) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreMaxが一致しません"))
-	}
-
-	if !AssertEqual("grade courses total_score_min", expected.TotalScoreMin, actual.TotalScoreMin) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreMinが一致しません"))
-	}
-
-	if !AssertWithinTolerance("grade courses total_score_avg", expected.TotalScoreAvg, actual.TotalScoreAvg, validateTotalScoreErrorTolerance) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreAvgが一致しません"))
-	}
-
-	if !AssertWithinTolerance("grade courses total_score_t_score", expected.TotalScoreTScore, actual.TotalScoreTScore, validateTotalScoreErrorTolerance) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のコースのTotalScoreTScoreが一致しません"))
-	}
-
-	if !AssertEqual("grade courses class_scores length", len(expected.ClassScores), len(actual.ClassScores)) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のClassScoresの数が一致しません"))
-	}
-
-	for i := 0; i < len(expected.ClassScores); i++ {
-		// webapp 側は新しい(partが大きい)classから順番に帰ってくるので古いクラスから見るようにしている
-		err := validateClassScore(expected.ClassScores[i], &actual.ClassScores[len(actual.ClassScores)-i-1])
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func validateClassScore(expected *model.ClassScore, actual *api.ClassScore) error {
-	if !AssertEqual("grade courses class_scores class_id", expected.ClassID, actual.ClassID) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスのIDが一致しません"))
-	}
-
-	if !AssertEqual("grade courses class_scores part", expected.Part, actual.Part) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスのpartが一致しません"))
-	}
-
-	if !AssertEqual("grade courses class_scores title", expected.Title, actual.Title) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスのタイトルが一致しません"))
-	}
-
-	if !AssertEqual("grade courses class_scores score", expected.Score, actual.Score) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスのスコアが一致しません"))
-	}
-
-	if !AssertEqual("grade courses class_scores submitters", expected.SubmitterCount, actual.Submitters) {
-		return failure.NewError(fails.ErrCritical, errInvalidResponse("成績確認のクラスの課題提出者の数が一致しません"))
 	}
 
 	return nil

--- a/benchmarker/scenario/verify.go
+++ b/benchmarker/scenario/verify.go
@@ -112,7 +112,7 @@ func verifyGrades(expected map[string]interface{}, res *api.GetGradeResponse) er
 				return err
 			}
 		case *model.CourseResult:
-			err := validateCourseResult(v, &resCourseResult)
+			err := assertEqualCourseResult(v, &resCourseResult)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- load中にvalidationの関数を呼んでcriticalエラーになる問題の修正
- 単純にレスポンスとモデルを比較する関数はどこからでも呼べるようにして `assert.go` に定義する案です。（良さそうなら他の同様の関数も切り出して複雑なverify/validationのロジックと単純な比較を切り分けたいという思い）