### PR TITLE
AnnouncementList:SubmitAssignmentの得点比率を1:3に変更

### DIFF
--- a/benchmarker/score/calc.go
+++ b/benchmarker/score/calc.go
@@ -6,7 +6,7 @@ type mag int64      // 1回でn点
 type fraction int64 // n回で1点
 
 var scoreCoefTable = map[score.ScoreTag]interface{}{
-	ScoreSubmitAssignment:    mag(1),
+	ScoreSubmitAssignment:    mag(3),
 	ScoreGetAnnouncementList: mag(1),
 }
 


### PR DESCRIPTION
コースシナリオが早く回ると、課題提出回数は増加するが、一度に取得できる未読お知らせも多くなるためお知らせリストのGET回数が減少する。
このときコースシナリオ自体は早くなったにも関わらず得点は+-0となり変化が小さくなってしまう。

（↓以下のパラメータを変更するとわかる。5:24あたり）
http://localhost:23000/explore?orgId=1&left=%5B%221631366996000%22,%221631396836000%22,%22Prometheus%22,%7B%22exemplar%22:true,%22expr%22:%22sum(isucon11f_bench_score_tag%7Binstance%3D%5C%22final-dev-bench-01%5C%22,%20tag%3D%5C%22GetAnnouncementList%5C%22%7D%20*%201)%20%2B%20sum(isucon11f_bench_score_tag%7Binstance%3D%5C%22final-dev-bench-01%5C%22,%20tag%3D%5C%22SubmitAssignment%5C%22%7D%20*%205)%22%7D%5D

そのためスコアの比率はAnnouncementList:SubmitAssignmentで1:3とする
0.5:5に戻さないのは「各シナリオサイクルを回すリソースが偏った際に発生するブレ」を抑えるため。