### PR TITLE
Add ruby and php to site.yml

### DIFF
--- a/provisioning/ansible/site.yml
+++ b/provisioning/ansible/site.yml
@@ -17,6 +17,8 @@
     - langs.go
     - langs.rust
     - langs.nodejs
+    - langs.ruby
+    - langs.php
     - contestant
 
 - name: "bench roles"


### PR DESCRIPTION
#712 で PHP と Ruby が site.yml に含まれて無さそうだったので追記しました。