### PR TITLE
Fix rustup options

### DIFF
--- a/provisioning/ansible/roles/langs.rust/tasks/main.yml
+++ b/provisioning/ansible/roles/langs.rust/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Install Rust"
   become_user: isucon
   shell: |
-    curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --profile default --default-toolchain 1.55.0
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --profile default --default-toolchain 1.55.0 -c rustfmt
 
 - name: "Add PATH for Rust"
   become_user: isucon


### PR DESCRIPTION
`rustup update 1.53.0` で 1.53 をインストールしてるにも関わらずデフォルトでインストールされてる stable が使われてたので、その不要なインストールをやめました。 https://github.com/isucon/isucon10-final/blob/e858b2588a199f9c7407baacf48b53126b8aeed6/packer/files/itamae/cookbooks/langs/rust.rb#L9 を参考にオプション変更しました。