### PR TITLE
Add "-tls" to benchmarker options

### DIFF
--- a/provisioning/ansible/roles/bench.supervisor/files/etc/systemd/system/isuxportal-supervisor.service
+++ b/provisioning/ansible/roles/bench.supervisor/files/etc/systemd/system/isuxportal-supervisor.service
@@ -5,7 +5,7 @@ After=network.target cloud-config.service
 [Service]
 # 基本設定
 User=isucon
-ExecStart=/home/isucon/bin/isuxportal-supervisor /home/isucon/benchmarker/bin/benchmarker -prom-out /run/prometheus-node-exporter/textfile/bench.prom
+ExecStart=/home/isucon/bin/isuxportal-supervisor /home/isucon/benchmarker/bin/benchmarker -prom-out /run/prometheus-node-exporter/textfile/bench.prom -tls
 WorkingDirectory=/home/isucon/benchmarker
 LogsDirectory=isuxportal-supervisor
 LimitNOFILE=2000000


### PR DESCRIPTION
supervisor からベンチマーカー起動時に HTTPS 使うようにしていなかったのを修正しました