### PR TITLE
add isucholar-php-conf

### DIFF
--- a/provisioning/ansible/roles/contestant/tasks/nginx.yml
+++ b/provisioning/ansible/roles/contestant/tasks/nginx.yml
@@ -21,6 +21,7 @@
   with_items:
   - etc/nginx/nginx.conf
   - etc/nginx/sites-available/isucholar.conf
+  - etc/nginx/sites-available/isucholar-php.conf
   - etc/nginx/certificates/tls-cert.pem
   - etc/nginx/certificates/tls-key.pem
 


### PR DESCRIPTION
https://isucon.slack.com/archives/C027M58K4E4/p1631636449232600
を追加しました。
操作ミスで
https://github.com/isucon/isucon11-final/blob/main/provisioning/ansible/roles/contestant/files/etc/nginx/sites-available/isucholar-php.conf
だけ先に直pushしてしまったので、nginx.ymlのみの修正になります、すみません。