### PR TITLE
教員用ページのドロップダウンを開くボタンのhover:bg-primary-300を消す

### DIFF
--- a/webapp/frontend/components/ClassTable.vue
+++ b/webapp/frontend/components/ClassTable.vue
@@ -28,13 +28,7 @@
                 <div class="relative">
                   <fa-icon
                     icon="ellipsis-v"
-                    class="
-                      min-w-min
-                      px-2
-                      cursor-pointer
-                      rounded
-                      hover:bg-primary-300
-                    "
+                    class="min-w-min px-2 cursor-pointer rounded"
                     @click.stop="onClickClassDropdown(i)"
                   />
                   <div

--- a/webapp/frontend/components/CourseTable.vue
+++ b/webapp/frontend/components/CourseTable.vue
@@ -30,13 +30,7 @@
                 <div class="relative">
                   <fa-icon
                     icon="ellipsis-v"
-                    class="
-                      min-w-min
-                      px-2
-                      cursor-pointer
-                      rounded
-                      hover:bg-primary-300
-                    "
+                    class="min-w-min px-2 cursor-pointer rounded"
                     @click.stop="onClickCourseDropdown(i)"
                   />
                   <div


### PR DESCRIPTION
fix #775 