### PR TITLE
Fix tag "Project" for EBS volumes

### DIFF
--- a/provisioning/terraform-prd/bench.tf
+++ b/provisioning/terraform-prd/bench.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "bench" {
     volume_size = "20"
     tags = {
       Name    = format("final-prd-bench-%02d", tonumber(each.key))
-      Project = "final-prd"
+      Project = "final"
     }
   }
 

--- a/provisioning/terraform-prd/contestant_instances.tf
+++ b/provisioning/terraform-prd/contestant_instances.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "contestant-1" {
     volume_size = "30"
     tags = {
       Name    = format("final-prd-contestant-%02d-1", tonumber(each.key))
-      Project = "final-prd"
+      Project = "final"
     }
   }
 
@@ -88,7 +88,7 @@ resource "aws_instance" "contestant-2" {
     volume_size = "30"
     tags = {
       Name    = format("final-prd-contestant-%02d-2", tonumber(each.key))
-      Project = "final-prd"
+      Project = "final"
     }
   }
 
@@ -134,7 +134,7 @@ resource "aws_instance" "contestant-3" {
     volume_size = "30"
     tags = {
       Name    = format("final-prd-contestant-%02d-3", tonumber(each.key))
-      Project = "final-prd"
+      Project = "final"
     }
   }
 


### PR DESCRIPTION
本番 EC2 インスタンスにつく EBS の `Project` タグが `final-prd` になっていたのを修正しました。 (本番環境のタグは `final` に統一しているため)