### PR TITLE
Allow ssh to contestant instances from bastion only

### DIFF
--- a/provisioning/terraform-prd/security_groups.tf
+++ b/provisioning/terraform-prd/security_groups.tf
@@ -34,6 +34,13 @@ resource "aws_security_group" "contestant" {
   description = "security group for final-prd team #${each.key} contestant instances"
 }
 
+data "aws_instance" "bastion" {
+  filter {
+    name   = "tag:Name"
+    values = ["isucon11-bastion"]
+  }
+}
+
 resource "aws_security_group_rule" "contestant-ingress-ssh" {
   for_each = toset(var.team_ids)
 
@@ -42,7 +49,8 @@ resource "aws_security_group_rule" "contestant-ingress-ssh" {
   protocol          = "tcp"
   from_port         = 22
   to_port           = 22
-  cidr_blocks       = ["0.0.0.0/0"]
+  #cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks = ["${data.aws_instance.bastion.public_ip}/32"]
 }
 
 resource "aws_security_group_rule" "contestant-ingress-benchmark" {


### PR DESCRIPTION
本番環境の SSH を bastion インスタンスからのみ許可するようにしました。
これは本番環境の動作確認時に選手の公開鍵がすでに追加されているので、競技開始前に長期間選手がアクセスできてしまう状態になるのを防ぐためです。 (IP アドレスを知っている必要があるので直ちに問題になるわけではないですが念の為)

当日朝には確実に revert します。