### PR TITLE
おしらせリストのprepareの厳格化

### DIFF
--- a/benchmarker/scenario/prepare.go
+++ b/benchmarker/scenario/prepare.go
@@ -636,6 +636,7 @@ func prepareCheckAnnouncementsList(ctx context.Context, a *agent.Agent, path, co
 	errMissingNext := fails.ErrorCritical(fmt.Errorf("お知らせリストの link header の next が空でないことが期待される場所で空でした"))
 	errUnnecessaryNext := fails.ErrorCritical(fmt.Errorf("お知らせリストの link header の next が空であることが期待される場所で空ではありませんでした"))
 	errNotExistPrevOtherThanFirstPage := errors.New("お知らせリストの最初以外のページの link header に prev が存在しませんでした")
+	errUnnecessaryPrev := errors.New("お知らせリストの link header の prev が空であることが期待される場所で空ではありませんでした")
 
 	hres, res, err := GetAnnouncementListAction(ctx, a, path, courseID)
 	if err != nil {
@@ -654,6 +655,9 @@ func prepareCheckAnnouncementsList(ctx context.Context, a *agent.Agent, path, co
 	}
 	if path != "" && prev == "" {
 		return "", errNotExistPrevOtherThanFirstPage
+	}
+	if path == "" && prev != "" {
+		return "", errUnnecessaryPrev
 	}
 
 	// 次のページが存在しない


### PR DESCRIPTION
close #819
next が必要ない時（お知らせが0のとき、20の倍数の時）にnextが空文字であることを検証する
最初のページに戻ってきたときにprevが空文字であることを検証する