### PR TITLE
Increase retry count to fetch ssh keys

### DIFF
--- a/provisioning/terraform-prd/contestant-user-data.sh.tpl
+++ b/provisioning/terraform-prd/contestant-user-data.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ~isucon/.ssh
-curl --retry 5 --retry-connrefused --max-time 10 --connect-timeout 5 "https://portal.isucon.net/api/ssh_public_keys?token=${checker_token}" > ~isucon/.ssh/authorized_keys
+curl --retry 10 --retry-connrefused --max-time 10 --connect-timeout 5 "https://portal.isucon.net/api/ssh_public_keys?token=${checker_token}" > ~isucon/.ssh/authorized_keys
 chmod 0700 ~isucon/.ssh
 chmod 0600 ~isucon/.ssh/authorized_keys
 chown -R isucon:isucon ~isucon/.ssh


### PR DESCRIPTION
SSH 鍵の失敗がしにくいようにリトライ回数増やしました。

本質的には `terraform apply` すると約90台のインスタンスをすべて作ってから Elastic IP を付与するためその間に cloud-init の処理が実行されてしまい、タイムアウトになってしまうのが問題のようでした。そのため以下のコマンドでチームごとに apply していく力技で解決しました (parallelism 上げてもどうにかなりそうですが、それで rate limit 引っかかっても手間になるのでこのような方法にしました)

```bash
for id in 1 221 299 3 153 633 65 42 295 213 17 321 163 337 34 193 40 578 165 429 358 209 459 57 269 83 4 231 179 457 35; do terraform apply -auto-approve -var-file checker_tokens.json -target 'aws_instance.contestant-1["'$id'"]' -target 'aws_eip.contestant-1["'$id'"]' -target 'aws_instance.contestant-2["'$id'"]' -target 'aws_eip.contestant-2["'$id'"]' -target 'aws_instance.contestant-3["'$id'"]' -target 'aws_eip.contestant-3["'$id'"]'; done
```

なのでこの変更は無くても通るようになっているはずですが、上記の問題修正のために再デプロイさせるついでに増やしたので、実際にデプロイされているものを差異が無いように PR にしました。