### PR TITLE
Lock AMI ID for production

### DIFF
--- a/provisioning/terraform-prd/bench.tf
+++ b/provisioning/terraform-prd/bench.tf
@@ -1,19 +1,3 @@
-data "aws_ami" "bench" {
-  owners      = ["self"]
-  most_recent = true
-  name_regex  = "^isucon11f-amd64-bench-\\d{8}-\\d{4}-[0-9a-f]{40}$"
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
-
 data "aws_ssm_parameter" "bench_token" {
   name = "/hako/isuxportal-prd/ISUXPORTAL_BENCH_TOKEN"
 }
@@ -21,7 +5,7 @@ data "aws_ssm_parameter" "bench_token" {
 resource "aws_instance" "bench" {
   for_each = toset(var.team_ids)
 
-  ami           = data.aws_ami.bench.id
+  ami           = "ami-0d0b6cd6f9ac9dc11"
   instance_type = "c5.xlarge"
 
   subnet_id         = aws_subnet.bench.id

--- a/provisioning/terraform-prd/contestant_instances.tf
+++ b/provisioning/terraform-prd/contestant_instances.tf
@@ -1,23 +1,7 @@
-data "aws_ami" "contestant" {
-  owners      = ["self"]
-  most_recent = true
-  name_regex  = "^isucon11f-amd64-contestant-\\d{8}-\\d{4}-[0-9a-f]{40}$"
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
-
 resource "aws_instance" "contestant-1" {
   for_each = toset(var.team_ids)
 
-  ami           = data.aws_ami.contestant.id
+  ami           = "ami-0a6d03a5126400384"
   instance_type = "c5.large"
 
   subnet_id         = aws_subnet.contestant[each.key].id
@@ -63,7 +47,7 @@ resource "aws_eip" "contestant-1" {
 resource "aws_instance" "contestant-2" {
   for_each = toset(var.team_ids)
 
-  ami           = data.aws_ami.contestant.id
+  ami           = "ami-0a6d03a5126400384"
   instance_type = "c5.large"
 
   subnet_id         = aws_subnet.contestant[each.key].id
@@ -109,7 +93,7 @@ resource "aws_eip" "contestant-2" {
 resource "aws_instance" "contestant-3" {
   for_each = toset(var.team_ids)
 
-  ami           = data.aws_ami.contestant.id
+  ami           = "ami-0a6d03a5126400384"
   instance_type = "c5.large"
 
   subnet_id         = aws_subnet.contestant[each.key].id


### PR DESCRIPTION
最新の AMI を使うようにしていたのを、今後 CI などで追加の AMI がビルドされても再作成しないように現在のバージョンに固定しておきます。