### PR TITLE
[Ruby] POST /api/announcements内でAnnouncementConflictが発生した時にrescue内でNoMethodErrorが発生するのを修正した

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -877,7 +877,7 @@ module Isucholar
           end
         end
       rescue AnnouncementConflict
-        announcement = db.xquery("SELECT * FROM `announcements` WHERE `id` = ?", json_params[:id])
+        announcement = db.xquery("SELECT * FROM `announcements` WHERE `id` = ?", json_params[:id]).first
         raise unless announcement
         if %i(course_id title message).any? { |k| announcement[k] != json_params[k] }
           halt 409, "An announcement with the same id already exists."


### PR DESCRIPTION
# 概要
https://github.com/isucon/isucon11-final/blob/a4ca72f2b4c470d93afe9edd572a2dbd563308fe/webapp/ruby/app.rb#L879-L882 で下記のようなエラーが発生したので修正しました

```
NoMethodError: undefined method `[]' for #<Mysql2::Result:0x00007fea7511c698 @query_options={:as=>:hash, :async=>false, :cast_booleans=>true, :symbolize_keys=>true, :database_timezone=>:utc, :application_timezone=>nil, :cache_rows=>true, :connect_flags=>2148540933, :cast=>true, :default_file=>nil, :default_group=>nil, :host=>"XXX.XXX.XXX.XXX", :port=>3306, :username=>"isucon", :password=>"XXXXXXXXX", :database=>"isucholar", :charset=>"utf8mb4", :reconnect=>true, :init_command=>"SET time_zone='+00:00';", :flags=>nil}, @server_flags={:no_good_index_used=>false, :no_index_used=>false, :query_was_slow=>true}>

        if %i(course_id title message).any? { |k| announcement[k] != json_params[k] }
                                                              ^^^
  from app.rb:882:in `block (2 levels) in <class:App>'
  from app.rb:882:in `any?'
  from app.rb:882:in `rescue in block in <class:App>'
  from app.rb:854:in `block in <class:App>'
  from sinatra/base.rb:1685:in `call'
  from sinatra/base.rb:1685:in `block in compile!'
  from sinatra/base.rb:1023:in `block (3 levels) in route!'
  from sinatra/base.rb:1042:in `route_eval'
```

# 原因＆修正方法
引用箇所のコードを見る感じ880行目では単一レコード（ `Hash` ）を `announcement` に代入したいように見えるのですが、`db.xquery` の戻り値は [`Mysql2::Result`](https://github.com/brianmario/mysql2/blob/0.5.4/lib/mysql2/result.rb) （取得したレコードの集合）なので実際には `Mysql2::Result` が `announcement` に代入されています。

そのため、 `.first` をつけて単一レコードを代入するようにして修正しました。